### PR TITLE
Windows/Linux improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:16.04
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN apt-get update && apt-get -y install \
+  build-essential \
+  cmake \
+  git \
+  libboost-all-dev \
+  libxerces-c-dev \
+  libxalan-c-dev \
+  libpng-dev \
+  libgtest-dev \
+  libtiff5-dev \
+  python-pip
+RUN pip install Genshi
+
+WORKDIR /git
+RUN git clone --branch='v0.2.3' https://github.com/ome/ome-cmake-superbuild.git
+
+WORKDIR /build
+RUN cmake \
+    -Dgit-dir=/git \
+    -Dbuild-prerequisites=OFF \
+    -Dome-superbuild_BUILD_gtest=ON \
+    -Dbuild-packages=ome-files \
+    /git/ome-cmake-superbuild
+RUN make
+RUN make install
+RUN ldconfig
+
+ADD . /git/ome-files-performance
+
+WORKDIR /build2
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/install \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=$OME_FILES_BUNDLE \
+  -DCMAKE_PROGRAM_PATH=$OME_FILES_BUNDLE/bin \
+  -DCMAKE_LIBRARY_PATH=$OME_FILES_BUNDLE/lib \
+  /git/ome-files-performance
+RUN cmake --build .
+RUN cmake --build . --target install
+
+WORKDIR /
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,4 @@ RUN apt-get update && apt-get -y install \
   maven
 RUN mvn clean install
 
-WORKDIR /
 CMD ["/bin/bash"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,12 @@ RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/install \
 RUN cmake --build .
 RUN cmake --build . --target install
 
-WORKDIR /
+WORKDIR /git/ome-files-performance
+RUN apt-get update && apt-get -y install \
+  default-jdk \
+  maven
+RUN mvn clean install
 
+WORKDIR /
 CMD ["/bin/bash"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,9 @@
-FROM ubuntu:16.04
+FROM openmicroscopy/ome-files-cpp-u1604
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN apt-get update && apt-get -y install \
-  build-essential \
-  cmake \
-  git \
-  libboost-all-dev \
-  libxerces-c-dev \
-  libxalan-c-dev \
-  libpng-dev \
-  libgtest-dev \
-  libtiff5-dev \
-  python-pip
-RUN pip install Genshi
-
-WORKDIR /git
-RUN git clone --branch='v0.2.3' https://github.com/ome/ome-cmake-superbuild.git
-
-WORKDIR /build
-RUN cmake \
-    -Dgit-dir=/git \
-    -Dbuild-prerequisites=OFF \
-    -Dome-superbuild_BUILD_gtest=ON \
-    -Dbuild-packages=ome-files \
-    /git/ome-cmake-superbuild
-RUN make
-RUN make install
-RUN ldconfig
+  default-jdk \
+  maven
 
 ADD . /git/ome-files-performance
 
@@ -41,9 +18,6 @@ RUN cmake --build .
 RUN cmake --build . --target install
 
 WORKDIR /git/ome-files-performance
-RUN apt-get update && apt-get -y install \
-  default-jdk \
-  maven
 RUN mvn clean install
 
 CMD ["/bin/bash"]

--- a/run_performance
+++ b/run_performance
@@ -1,0 +1,17 @@
+# Clean results folder
+mkdir -p /data/results
+rm /data/results/*
+
+# Java tests
+mvn -P metadata -Dtest.iterations=1 -Dtest.input=/data/BBC/NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=/data/results/bbbc-metadata-java.tsv exec:java
+mvn -P metadata -Dtest.iterations=1 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=/data/results/mitocheck-metadata-java.tsv exec:java
+
+mvn -P pixels -Dtest.iterations=1 -Dtest.input=/data/BBC/NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=/data/results/bbbc-pixels-java.tsv exec:java
+mvn -P pixels -Dtest.iterations=1 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=/data/results/mitocheck-pixels-java.tsv exec:java
+
+# C++ tests
+/install/bin/metadata-performance 1 /data/BBBC/NIRHTa-001.ome.tiff bbbc.ome.xml /data/results/bbbc-metadata-cpp.tsv
+/install/bin/metadata-performance 1 /data/mitocheck/00001_01.ome.tiff mitocheck.ome.xml /data/results/mitocheck-metadata-cpp.tsv
+
+/install/bin/pixels-performance 1 /data/BBBC/NIRHTa-001.ome.tiff bbbc.ome.tiff /data/results/bbbc-pixeldata-cpp.tsv
+/install/bin/pixels-performance 1 /data/mitocheck/00001_01.ome.tiff mitocheck.ome.tiff /data/results/mitocheck-pixeldata-cpp.tsv

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -73,8 +73,7 @@ cd "%WORKSPACE%"
 cd source
 call mvn clean install
 
-
-set "DATA_DIR=D:\performance"
+set "DATA_DIR=D:\data_performance"
 
 REM Run Java metadata performance tests
 

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -72,7 +72,7 @@ cmake --build . --target install || exit /b
 REM Build Java
 cd "%WORKSPACE%"
 cd source
-mvn install
+mvn clean install || exit /b
 
 REM Execute Java performance tests
 mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -68,27 +68,34 @@ cmake -G "Ninja" ^
 cmake --build . || exit /b
 cmake --build . --target install || exit /b
 
-
 REM Build Java
 cd "%WORKSPACE%"
 cd source
 call mvn clean install
 
-REM Execute Java performance tests
-call mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
 
-call mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-mitocheck-win-java.tsv exec:java
+set "DATA_DIR=D:\performance"
 
-call mvn -P pixels -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=%WORKSPACE%\results\bbbc-pixeldata-win.tsv exec:java
+REM Run Java metadata performance tests
 
-call mvn -P pixels -Dtest.iterations=1 -Dtest.input=D:\data_performance\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=%WORKSPACE%\results\mitocheck-pixeldata-win.tsv exec:java
+call mvn -P metadata -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
+call mvn -P metadata -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-mitocheck-win-java.tsv exec:java
+
+REM Run Java pixels performance tests
+
+call mvn -P pixels -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=%WORKSPACE%\results\bbbc-pixeldata-win-java.tsv exec:java
+call mvn -P pixels -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=%WORKSPACE%\results\mitocheck-pixeldata-win-java.tsv exec:java
 
 REM Execute C++ performance tests
 cd "%WORKSPACE%"
 
-install\bin\metadata-performance 1 D:\data_performance\BBBC\NIRHTa-001.ome.tiff bbbc.ome.xml results/bbbc-metadata-win.tsv
-install\bin\metadata-performance 1 D:\data_performance\mitocheck\00001_01.ome.tiff mitocheck.ome.xml results/mitocheck-metadata-win.tsv
+REM Run C++ metadata tests
 
-install\bin\pixels-performance 1 D:\data_performance\BBBC\NIRHTa-001.ome.tiff bbbc.ome.tiff results/bbbc-pixeldata-win.tsv
-install\bin\pixels-performance 1 D:\data_performance\mitocheck\00001_01.ome.tiff mitocheck.ome.tiff results/mitocheck-pixeldata-win.tsv
+install\bin\metadata-performance 14 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc.ome.xml results/bbbc-metadata-win-cpp.tsv
+install\bin\metadata-performance 1 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck.ome.xml results/mitocheck-metadata-win-cpp.tsv
+
+REM Run C++ pixels performance tests
+i
+nstall\bin\pixels-performance 1 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc.ome.tiff results/bbbc-pixeldata-win-cpp.tsv
+install\bin\pixels-performance 1 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck.ome.tiff results/mitocheck-pixeldata-win-cpp.tsv
 

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -71,7 +71,7 @@ cmake --build . --target install || exit /b
 REM Build Java
 cd "%WORKSPACE%"
 cd source
-call mvn clean install
+call mvn clean install || exit /b
 
 set "DATA_DIR=D:\data_performance"
 

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -77,24 +77,23 @@ set "DATA_DIR=D:\data_performance"
 
 REM Run Java metadata performance tests
 
-call mvn -P metadata -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
-call mvn -P metadata -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-mitocheck-win-java.tsv exec:java
+call mvn -P metadata -Dtest.iterations=10 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
+call mvn -P metadata -Dtest.iterations=10 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-mitocheck-win-java.tsv exec:java
 
 REM Run Java pixels performance tests
 
-call mvn -P pixels -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=%WORKSPACE%\results\bbbc-pixeldata-win-java.tsv exec:java
-call mvn -P pixels -Dtest.iterations=1 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=%WORKSPACE%\results\mitocheck-pixeldata-win-java.tsv exec:java
+call mvn -P pixels -Dtest.iterations=5 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=%WORKSPACE%\results\bbbc-pixeldata-win-java.tsv exec:java
+call mvn -P pixels -Dtest.iterations=5 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=%WORKSPACE%\results\mitocheck-pixeldata-win-java.tsv exec:java
 
 REM Execute C++ performance tests
 cd "%WORKSPACE%"
 
 REM Run C++ metadata tests
 
-install\bin\metadata-performance 14 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc.ome.xml results/bbbc-metadata-win-cpp.tsv
-install\bin\metadata-performance 1 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck.ome.xml results/mitocheck-metadata-win-cpp.tsv
+install\bin\metadata-performance 10 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc.ome.xml results/bbbc-metadata-win-cpp.tsv
+install\bin\metadata-performance 10 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck.ome.xml results/mitocheck-metadata-win-cpp.tsv
 
 REM Run C++ pixels performance tests
-i
-nstall\bin\pixels-performance 1 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc.ome.tiff results/bbbc-pixeldata-win-cpp.tsv
-install\bin\pixels-performance 1 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck.ome.tiff results/mitocheck-pixeldata-win-cpp.tsv
+install\bin\pixels-performance 5 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc.ome.tiff results/bbbc-pixeldata-win-cpp.tsv
+install\bin\pixels-performance 5 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck.ome.tiff results/mitocheck-pixeldata-win-cpp.tsv
 

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -70,6 +70,7 @@ cmake --build . --target install || exit /b
 
 
 REM Build Java
+cd "%WORKSPACE%"
 cd source
 mvn install
 

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -72,10 +72,10 @@ cmake --build . --target install || exit /b
 REM Build Java
 cd "%WORKSPACE%"
 cd source
-mvn clean install || exit /b
+call mvn clean install
 
 REM Execute Java performance tests
-mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
+call mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
 
 
 cd "%WORKSPACE%"

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -42,7 +42,7 @@ mkdir install
 mkdir results
 cd build
 
-set "PATH=C:\Tools\ninja;%OME_FILES_BUNDLE%\bin;%PATH%"
+set "PATH=C:\Tools\ninja;%OME_FILES_BUNDLE%\bin;%MAVEN_PATH%\bin;%PATH%"
 
 if [%build_version%] == [11] (
     call "%VS110COMNTOOLS%..\..\VC\vcvarsall.bat" %build_arch%
@@ -67,6 +67,15 @@ cmake -G "Ninja" ^
 
 cmake --build . || exit /b
 cmake --build . --target install || exit /b
+
+
+REM Build Java
+cd source
+mvn install
+
+REM Execute Java performance tests
+mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
+
 
 cd "%WORKSPACE%"
 

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -77,7 +77,13 @@ call mvn clean install
 REM Execute Java performance tests
 call mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
 
+call mvn -P metadata -Dtest.iterations=1 -Dtest.input=D:\data_performance\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-mitocheck-win-java.tsv exec:java
 
+call mvn -P pixels -Dtest.iterations=1 -Dtest.input=D:\data_performance\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=%WORKSPACE%\results\bbbc-pixeldata-win.tsv exec:java
+
+call mvn -P pixels -Dtest.iterations=1 -Dtest.input=D:\data_performance\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=%WORKSPACE%\results\mitocheck-pixeldata-win.tsv exec:java
+
+REM Execute C++ performance tests
 cd "%WORKSPACE%"
 
 install\bin\metadata-performance 1 D:\data_performance\BBBC\NIRHTa-001.ome.tiff bbbc.ome.xml results/bbbc-metadata-win.tsv

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -29,6 +29,7 @@ set build_system=MSBuild
 set verbose=OFF
 
 set "OME_HOME=%OME_FILES_BUNDLE%"
+set "DATA_DIR=D:\data_performance"
 
 cd "%WORKSPACE%"
 if exist "build" (
@@ -72,8 +73,6 @@ REM Build Java
 cd "%WORKSPACE%"
 cd source
 call mvn clean install || exit /b
-
-set "DATA_DIR=D:\data_performance"
 
 REM Run Java metadata performance tests
 

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -5,10 +5,10 @@ mkdir -p /data/results
 rm /data/results/*
 
 # Java tests
-mvn -P metadata -Dtest.iterations=1 -Dtest.input=/data/BBC/NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=/data/results/bbbc-metadata-java.tsv exec:java
+mvn -P metadata -Dtest.iterations=1 -Dtest.input=/data/BBBC/NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.xml -Dtest.results=/data/results/bbbc-metadata-java.tsv exec:java
 mvn -P metadata -Dtest.iterations=1 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=mitocheck.ome.xml -Dtest.results=/data/results/mitocheck-metadata-java.tsv exec:java
 
-mvn -P pixels -Dtest.iterations=1 -Dtest.input=/data/BBC/NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=/data/results/bbbc-pixels-java.tsv exec:java
+mvn -P pixels -Dtest.iterations=1 -Dtest.input=/data/BBBC/NIRHTa-001.ome.tiff -Dtest.output=bbbc.ome.tiff -Dtest.results=/data/results/bbbc-pixels-java.tsv exec:java
 mvn -P pixels -Dtest.iterations=1 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=mitocheck.ome.tiff -Dtest.results=/data/results/mitocheck-pixels-java.tsv exec:java
 
 # C++ tests

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 # Clean results folder
 mkdir -p /data/results
 rm /data/results/*

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -126,7 +126,7 @@ public final class PixelsPerformance {
         result.add("pixeldata.read.init", infile, read_start, read_init);
         result.add("pixeldata.read.pixels", infile, read_init, read_end);
 
-        Files.delete(outfile);
+        Files.deleteIfExists(outfile);
 
         Timepoint write_start = new Timepoint();
         Timepoint write_init = null;


### PR DESCRIPTION
See https://trello.com/c/zPt990vm/7-run-benchmarking-on-linux-node and https://trello.com/c/pWGZjdMz/5-add-java-benchmarking-scripts for more context

As a follow-up of https://github.com/openmicroscopy/ome-files-performance/pull/3, this PR improves the benchmarking suite of Bio-Formats and OME Files C++ for Linux & Windows with the following changes:

- fixes the `Files.delete()` call to use `Files.deleteIfExists()` instead
- Windows: migrates the Java build and execution steps to the `jenkins-build.bat` script so that it can be executed as part of CI
- Linux: adds a Dockerfile based on https://github.com/ome/ome-files-py/pull/4 allowing to build the Java and C++ and a script to run the benchmarking

Testing:
- for Windows, the build should be exectued via https://ci.openmicroscopy.org/job/OME-FILES-performance-win/
- for Linux, using `beluga`, run the following:
  ```
  $ docker build -t <container> .
  $ docker run --rm -it -v /scratch/tmp/data:/data <container> bash
  $ sh scripts/run_benchmarking
  ```