### PR TITLE
Remove extra fileseparator in the C++ results table

### DIFF
--- a/src/main/cpp/result.cpp
+++ b/src/main/cpp/result.cpp
@@ -62,5 +62,5 @@ result(std::ostream& os,
      << boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().user // process user time
      << '\t'
      << boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().system // process system time
-     << '\t' << '\n';
+     << '\n';
 }


### PR DESCRIPTION
This extra tab was causing confusion when paring the CSV using pandas by shifting the column names. This commit should match the Java behavior