### PR TITLE
Delete output file if it exists before writing

### DIFF
--- a/src/main/cpp/pixels-performance.cpp
+++ b/src/main/cpp/pixels-performance.cpp
@@ -137,6 +137,10 @@ int main(int argc, char *argv[])
               throw ome::files::FormatException("MetadataStore does not implement MetadataRetrieve");
             }
 
+          // To keep the logic the same as for JACE, even though it's unnecessary here
+          if(boost::filesystem::exists(outfile))
+            boost::filesystem::remove(outfile);
+
           timepoint write_start;
           timepoint write_init;
           timepoint close_start;

--- a/src/main/jace/pixels-performance.cpp
+++ b/src/main/jace/pixels-performance.cpp
@@ -145,6 +145,10 @@ int main(int argc, char *argv[])
           result(results, "pixeldata.read.init", infile, read_start, read_init);
           result(results, "pixeldata.read.pixels", infile, read_init, read_end);
 
+          // The Java writer doesn't automatically truncate the output file.
+          if(boost::filesystem::exists(outfile))
+            boost::filesystem::remove(outfile);
+
           timepoint write_start;
           timepoint write_init;
 


### PR DESCRIPTION
For the JACE pixels-performace-jace test, this will ensure it writes a new file rather than opening an existing one.