### PR TITLE
Add tubhiswt fileset to the benchmarking suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbesson/ome-files-cpp-u1604
+FROM openmicroscopy/ome-files-cpp-u1604
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # Install JDK7 and Maven

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -110,11 +110,13 @@ REM Run Java metadata performance tests
 
 call mvn -P metadata -Dtest.iterations=10 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc-java.ome.xml -Dtest.results=%WORKSPACE%\results\bbbc-metadata-win-java.tsv exec:java
 call mvn -P metadata -Dtest.iterations=10 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck-java.ome.xml -Dtest.results=%WORKSPACE%\results\mitocheck-metadata-win-java.tsv exec:java
+call mvn -P metadata -Dtest.iterations=10 -Dtest.input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif -Dtest.output=tubhiswt-java.ome.xml -Dtest.results=%WORKSPACE%\results\tubhiswt-metadata-win-java.tsv exec:java
 
 REM Run Java pixels performance tests
 
 call mvn -P pixels -Dtest.iterations=3 -Dtest.input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff -Dtest.output=bbbc-java.ome.tiff -Dtest.results=%WORKSPACE%\results\bbbc-pixeldata-win-java.tsv exec:java
 call mvn -P pixels -Dtest.iterations=3 -Dtest.input=%DATA_DIR%\mitocheck\00001_01.ome.tiff -Dtest.output=mitocheck-java.ome.tiff -Dtest.results=%WORKSPACE%\results\mitocheck-pixeldata-win-java.tsv exec:java
+call mvn -P pixels -Dtest.iterations=3 -Dtest.input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif -Dtest.output=tubhiswt-java.ome.tiff -Dtest.results=%WORKSPACE%\results\tubhiswt-pixeldata-win-java.tsv exec:java
 
 REM Execute C++ performance tests
 cd "%WORKSPACE%"
@@ -123,8 +125,10 @@ REM Run C++ metadata tests
 
 install\bin\metadata-performance 10 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc-cpp.ome.xml results/bbbc-metadata-win-cpp.tsv
 install\bin\metadata-performance 10 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck-cpp.ome.xml results/mitocheck-metadata-win-cpp.tsv
+install\bin\metadata-performance 10 %DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif tubhiswt-cpp.ome.xml results/tubhiswt-metadata-win-cpp.tsv
 
 REM Run C++ pixels performance tests
 install\bin\pixels-performance 3 %DATA_DIR%\BBBC\NIRHTa-001.ome.tiff bbbc-cpp.ome.tiff results/bbbc-pixeldata-win-cpp.tsv
 install\bin\pixels-performance 3 %DATA_DIR%\mitocheck\00001_01.ome.tiff mitocheck-cpp.ome.tiff results/mitocheck-pixeldata-win-cpp.tsv
+install\bin\pixels-performance 3 %DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif tubhiswt-cpp.ome.tiff results/tubhiswt-pixeldata-win-cpp.tsv
 

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -22,10 +22,10 @@ cd $BF_JACE_HOME
 /install/bin/metadata-performance-jace 10 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.xml /data/results/bbbc-metadata-linux-jace.tsv
 /install/bin/metadata-performance-jace 10 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.xml /data/results/mitocheck-metadata-linux-jace.tsv
 # Throws boost: mutex exception
-# /install/bin/metadata-performance-jace 10 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.xml /data/results/tubhiswt-metadata-linux-jace.tsv
+/install/bin/metadata-performance-jace 10 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.xml /data/results/tubhiswt-metadata-linux-jace.tsv || true
 
 # Currently takes ~1h30 to complete per OME-TIFF - needs investigation
-# /install/bin/pixels-performance-jace 3 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv
+/install/bin/pixels-performance-jace 3 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 3 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.tiff /data/results/mitocheck-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 3 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.tiff /data/results/tubhiswt-pixeldata-linux-jace.tsv
 

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -21,7 +21,8 @@ mvn -P pixels -Dtest.iterations=3 -Dtest.input=/data/tubhiswt-4D/tubhiswt_C0_TP0
 cd $BF_JACE_HOME
 /install/bin/metadata-performance-jace 10 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.xml /data/results/bbbc-metadata-linux-jace.tsv
 /install/bin/metadata-performance-jace 10 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.xml /data/results/mitocheck-metadata-linux-jace.tsv
-/install/bin/metadata-performance-jace 10 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.xml /data/results/tubhiswt-metadata-linux-jace.tsv
+# Throws boost: mutex exception
+# /install/bin/metadata-performance-jace 10 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.xml /data/results/tubhiswt-metadata-linux-jace.tsv
 
 # Currently takes ~1h30 to complete per OME-TIFF - needs investigation
 # /install/bin/pixels-performance-jace 3 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -5,28 +5,34 @@ set -x
 # Clean results folder
 mkdir -p /data/results
 mkdir -p /data/out
-rm /data/results/*
-rm /data/out/*
+rm /data/results/* || echo "No results"
+rm /data/out/* || echo "No output"
 
 # Java tests
 mvn -P metadata -Dtest.iterations=10 -Dtest.input=/data/BBBC/NIRHTa-001.ome.tiff -Dtest.output=/data/out/bbbc-java.ome.xml -Dtest.results=/data/results/bbbc-metadata-linux-java.tsv exec:java
 mvn -P metadata -Dtest.iterations=10 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=/data/out/mitocheck-java.ome.xml -Dtest.results=/data/results/mitocheck-metadata-linux-java.tsv exec:java
+mvn -P metadata -Dtest.iterations=10 -Dtest.input=/data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif -Dtest.output=/data/out/tubhiswt-java.ome.xml -Dtest.results=/data/results/tubhiswt-metadata-linux-java.tsv exec:java
 
 mvn -P pixels -Dtest.iterations=3 -Dtest.input=/data/BBBC/NIRHTa-001.ome.tiff -Dtest.output=/data/out/bbbc-java.ome.tiff -Dtest.results=/data/results/bbbc-pixeldata-linux-java.tsv exec:java
 mvn -P pixels -Dtest.iterations=3 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=/data/out/mitocheck-java.ome.tiff -Dtest.results=/data/results/mitocheck-pixeldata-linux-java.tsv exec:java
+mvn -P pixels -Dtest.iterations=3 -Dtest.input=/data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif -Dtest.output=/data/out/tubhiswt-java.ome.tiff -Dtest.results=/data/results/tubhiswt-pixeldata-linux-java.tsv exec:java
 
 # JACE tests
 cd $BF_JACE_HOME
 /install/bin/metadata-performance-jace 10 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.xml /data/results/bbbc-metadata-linux-jace.tsv
 /install/bin/metadata-performance-jace 10 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.xml /data/results/mitocheck-metadata-linux-jace.tsv
+/install/bin/metadata-performance-jace 10 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.xml /data/results/tubhiswt-metadata-linux-jace.tsv
 
 # Currently takes ~1h30 to complete per OME-TIFF - needs investigation
 # /install/bin/pixels-performance-jace 3 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 3 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.tiff /data/results/mitocheck-pixeldata-linux-jace.tsv
+/install/bin/pixels-performance-jace 3 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.tiff /data/results/tubhiswt-pixeldata-linux-jace.tsv
 
 # C++ tests
 /install/bin/metadata-performance 10 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-cpp.ome.xml /data/results/bbbc-metadata-linux-cpp.tsv
 /install/bin/metadata-performance 10 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-cpp.ome.xml /data/results/mitocheck-metadata-linux-cpp.tsv
+/install/bin/metadata-performance 10 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-cpp.ome.xml /data/results/tubhiswt-metadata-linux-cpp.tsv
 
 /install/bin/pixels-performance 3 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-cpp.ome.tiff /data/results/bbbc-pixeldata-linux-cpp.tsv
 /install/bin/pixels-performance 3 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-cpp.ome.tiff /data/results/mitocheck-pixeldata-linux-cpp.tsv
+/install/bin/pixels-performance 3 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-cpp.ome.tiff /data/results/tubhiswt-pixeldata-linux-cpp.tsv

--- a/src/main/cpp/metadata-performance.cpp
+++ b/src/main/cpp/metadata-performance.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
           timepoint read_start;
 
           std::cout << "pass " << i << ": read init...";
-          if(infile.extension() == ".tiff")
+          if(infile.extension() == ".tiff" || infile.extension() == ".tif")
             {
               // OME-TIFF file
               try

--- a/src/main/jace/metadata-performance.cpp
+++ b/src/main/jace/metadata-performance.cpp
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
           timepoint read_start;
 
           std::cout << "pass " << i << ": read init...";
-          if(infile.extension() == ".tiff")
+          if(infile.extension() == ".tiff" || infile.extension() == ".tif")
             {
               // OME-TIFF file
               try

--- a/src/main/java/ome/files/performance/MetadataPerformance.java
+++ b/src/main/java/ome/files/performance/MetadataPerformance.java
@@ -81,7 +81,8 @@ public final class MetadataPerformance {
 
         System.out.print("pass " + i + ": read init...");
         String omexml;
-        if(infile.toString().endsWith(".tiff")) { // OME-TIFF file
+        if(infile.toString().endsWith(".tiff") ||
+           infile.toString().endsWith(".tif")) { // OME-TIFF file
           omexml = new TiffParser(infile.toString()).getComment();
         } else { // XML file
           omexml = DataTools.readFile(infile.toString());// read infile


### PR DESCRIPTION
Adds the [OME-TIFF tubhiswt fileset](http://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-4D/) to the performance datasets to be benchmarked.