### PR TITLE
java and jace PixelsPerformance: Write strips to match the C++ behaviour

### DIFF
--- a/src/main/cpp/pixels-performance.cpp
+++ b/src/main/cpp/pixels-performance.cpp
@@ -151,6 +151,7 @@ int main(int argc, char *argv[])
             std::unique_ptr<ome::files::FormatWriter> writer = std::make_unique<ome::files::out::OMETIFFWriter>();
             writer->setMetadataRetrieve(retrieve);
             writer->setInterleaved(interleaved.at(0));
+            dynamic_cast<ome::files::out::OMETIFFWriter &>(*writer.get()).setBigTIFF(true);
             writer->setId(outfile);
             std::cout << "done\n" << std::flush;
 

--- a/src/main/jace/pixels-performance.cpp
+++ b/src/main/jace/pixels-performance.cpp
@@ -161,6 +161,7 @@ int main(int argc, char *argv[])
             FormatWriter writer = java_cast<FormatWriter>(ometiffwriter);
             writer.setMetadataRetrieve(meta);
             writer.setInterleaved(true);
+            ometiffwriter.setBigTiff(true);
             writer.setId(outfile.string());
             std::cout << "done\n" << std::flush;
 

--- a/src/main/jace/pixels-performance.cpp
+++ b/src/main/jace/pixels-performance.cpp
@@ -182,7 +182,7 @@ int main(int argc, char *argv[])
                   {
                     int sizeX = meta.getPixelsSizeX(series).getNumberValue().intValue();
                     IFD ifd;
-                    int rows = 65535 / sizeX;
+                    int rows = 65536 / sizeX;
                     if (rows < 1) {
                       rows = 1;
                     }

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -161,7 +161,7 @@ public final class PixelsPerformance {
                   {
                     int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
                     IFD ifd = new IFD();
-                    int rows = 65535 / sizeX;
+                    int rows = 65536 / sizeX;
                     if (rows < 1) {
                       rows = 1;
                     }

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -55,9 +55,11 @@ import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
 import loci.formats.in.OMETiffReader;
 import loci.formats.out.OMETiffWriter;
+import loci.formats.out.TiffWriter;
 import loci.formats.FormatReader;
 import loci.formats.FormatWriter;
 
+import loci.formats.tiff.IFD;
 import loci.formats.tiff.TiffParser;
 
 public final class PixelsPerformance {
@@ -156,8 +158,15 @@ public final class PixelsPerformance {
 
                 for (int plane = 0; plane < planes.size(); ++plane)
                   {
+                    int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
+                    IFD ifd = new IFD();
+                    int rows = 65535 / sizeX;
+                    if (rows < 1) {
+                      rows = 1;
+                    }
+                    ifd.put(IFD.ROWS_PER_STRIP, rows);
                     byte[] data = planes.get(plane);
-                    writer.saveBytes(plane, data);
+                    ((TiffWriter) writer).saveBytes(plane, data, ifd);
                     System.out.print(".");
                     System.out.flush();
                   }

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -141,6 +141,7 @@ public final class PixelsPerformance {
             writer.setMetadataRetrieve(meta);
             writer.setWriteSequentially(true);
             writer.setInterleaved(true);
+            ((OMETiffWriter)writer).setBigTiff(true);
             writer.setId(outfile.toString());
             System.out.println("done");
             System.out.flush();


### PR DESCRIPTION
Match the C++ strip size, using the logic from ImageConverter.