### PR TITLE
Enable BigTIFF when writing pixel data

### DIFF
--- a/src/main/cpp/pixels-performance.cpp
+++ b/src/main/cpp/pixels-performance.cpp
@@ -151,6 +151,7 @@ int main(int argc, char *argv[])
             std::unique_ptr<ome::files::FormatWriter> writer = std::make_unique<ome::files::out::OMETIFFWriter>();
             writer->setMetadataRetrieve(retrieve);
             writer->setInterleaved(interleaved.at(0));
+            dynamic_cast<ome::files::out::OMETIFFWriter &>(*writer.get()).setBigTIFF(true);
             writer->setId(outfile);
             std::cout << "done\n" << std::flush;
 

--- a/src/main/jace/pixels-performance.cpp
+++ b/src/main/jace/pixels-performance.cpp
@@ -156,6 +156,7 @@ int main(int argc, char *argv[])
             FormatWriter writer = java_cast<FormatWriter>(ometiffwriter);
             writer.setMetadataRetrieve(meta);
             writer.setInterleaved(true);
+            ometiffwriter.setBigTiff(true);
             writer.setId(outfile.string());
             std::cout << "done\n" << std::flush;
 

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -139,6 +139,7 @@ public final class PixelsPerformance {
             writer.setMetadataRetrieve(meta);
             writer.setWriteSequentially(true);
             writer.setInterleaved(true);
+            ((OMETiffWriter)writer).setBigTiff(true);
             writer.setId(outfile.toString());
             System.out.println("done");
             System.out.flush();


### PR DESCRIPTION
Enable BigTIFF for all three writer tests.

Testing:

Files from `beluga:/scratch/tmp/data/out/`.  Compare the content of the written BigTIFF files between the languages.  What accounts for the size variance?
