### PR TITLE
Final benchmarking changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-u1604
+FROM openmicroscopy/ome-files-cpp-u1604:0.3.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # Install JDK7 and Maven

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -33,7 +33,7 @@ cd $BF_JACE_HOME
 # Throws boost: mutex exception
 /install/bin/metadata-performance-jace 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.xml /data/results/tubhiswt-metadata-linux-jace.tsv || true
 
-# Takes ~1h30 to complete and crashes at the second run with an OOM
-/install/bin/pixels-performance-jace 1 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 20 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.tiff /data/results/mitocheck-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.tiff /data/results/tubhiswt-pixeldata-linux-jace.tsv
+# NB: takes ~1h30 to complete
+/install/bin/pixels-performance-jace 6 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -17,6 +17,15 @@ mvn -P pixels -Dtest.iterations=20 -Dtest.input=/data/BBBC/NIRHTa-001.ome.tiff -
 mvn -P pixels -Dtest.iterations=20 -Dtest.input=/data/mitocheck/00001_01.ome.tiff -Dtest.output=/data/out/mitocheck-java.ome.tiff -Dtest.results=/data/results/mitocheck-pixeldata-linux-java.tsv exec:java
 mvn -P pixels -Dtest.iterations=20 -Dtest.input=/data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif -Dtest.output=/data/out/tubhiswt-java.ome.tiff -Dtest.results=/data/results/tubhiswt-pixeldata-linux-java.tsv exec:java
 
+# C++ tests
+/install/bin/metadata-performance 20 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-cpp.ome.xml /data/results/bbbc-metadata-linux-cpp.tsv
+/install/bin/metadata-performance 20 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-cpp.ome.xml /data/results/mitocheck-metadata-linux-cpp.tsv
+/install/bin/metadata-performance 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-cpp.ome.xml /data/results/tubhiswt-metadata-linux-cpp.tsv
+
+/install/bin/pixels-performance 20 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-cpp.ome.tiff /data/results/bbbc-pixeldata-linux-cpp.tsv
+/install/bin/pixels-performance 20 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-cpp.ome.tiff /data/results/mitocheck-pixeldata-linux-cpp.tsv
+/install/bin/pixels-performance 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-cpp.ome.tiff /data/results/tubhiswt-pixeldata-linux-cpp.tsv
+
 # JACE tests
 cd $BF_JACE_HOME
 /install/bin/metadata-performance-jace 20 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.xml /data/results/bbbc-metadata-linux-jace.tsv
@@ -28,12 +37,3 @@ cd $BF_JACE_HOME
 /install/bin/pixels-performance-jace 1 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-jace.ome.tiff /data/results/bbbc-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 20 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-jace.ome.tiff /data/results/mitocheck-pixeldata-linux-jace.tsv
 /install/bin/pixels-performance-jace 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-jace.ome.tiff /data/results/tubhiswt-pixeldata-linux-jace.tsv
-
-# C++ tests
-/install/bin/metadata-performance 20 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-cpp.ome.xml /data/results/bbbc-metadata-linux-cpp.tsv
-/install/bin/metadata-performance 20 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-cpp.ome.xml /data/results/mitocheck-metadata-linux-cpp.tsv
-/install/bin/metadata-performance 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-cpp.ome.xml /data/results/tubhiswt-metadata-linux-cpp.tsv
-
-/install/bin/pixels-performance 20 /data/BBBC/NIRHTa-001.ome.tiff /data/out/bbbc-cpp.ome.tiff /data/results/bbbc-pixeldata-linux-cpp.tsv
-/install/bin/pixels-performance 20 /data/mitocheck/00001_01.ome.tiff /data/out/mitocheck-cpp.ome.tiff /data/results/mitocheck-pixeldata-linux-cpp.tsv
-/install/bin/pixels-performance 20 /data/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif /data/out/tubhiswt-cpp.ome.tiff /data/results/tubhiswt-pixeldata-linux-cpp.tsv

--- a/src/main/jace/pixels-performance.cpp
+++ b/src/main/jace/pixels-performance.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
       boost::filesystem::path outfile(argv[3]);
       boost::filesystem::path resultfile(argv[4]);
 
-      JavaTools::createJVM(4096);
+      JavaTools::createJVM(8192);
       std::unique_ptr<OMEXMLService> service = std::make_unique<OMEXMLServiceImpl>();
 
       std::ofstream results(resultfile.string().c_str());


### PR DESCRIPTION
Changes for the final benchmarking results

- use 0.3.0 tag for OME Files C++ Docker image
- increase the JVM for JACE pixel benchmarking
- move JACE tests to the end
- reincreases the number of pixeldata executions 

This PR should be tested:
- on Windows via the automated https://ci.openmicroscopy.org/job/OME-FILES-performance-win job
- on Linux via building and executing the benchmarking script