### PR TITLE
Add separate OME-TIFF tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,6 @@
 
     <!-- NB: Override argLine property for extra maven-surefire-plugin args. -->
     <argLine/>
-
-    <test.iterations>1</test.iterations>
-    <test.input>test.file</test.input>
-    <test.output>test.write</test.output>
-    <test.results>test.results</test.results>
   </properties>
   <build>
     <defaultGoal>install</defaultGoal>
@@ -85,6 +80,15 @@
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>2.10</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -174,105 +178,6 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>metadata</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>1.2.1</version>
-            <executions>
-              <execution>
-                <id>metadata</id>
-                <goals>
-                  <goal>java</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <mainClass>ome.files.performance.MetadataPerformance</mainClass>
-              <arguments>
-                <argument>${test.iterations}</argument>
-                <argument>${test.input}</argument>
-                <argument>${test.output}</argument>
-                <argument>${test.results}</argument>
-              </arguments>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>pixels</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>1.2.1</version>
-            <executions>
-              <execution>
-                <id>metadata</id>
-                <goals>
-                  <goal>java</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <mainClass>ome.files.performance.PixelsPerformance</mainClass>
-              <arguments>
-                <argument>${test.iterations}</argument>
-                <argument>${test.input}</argument>
-                <argument>${test.output}</argument>
-                <argument>${test.results}</argument>
-              </arguments>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>ometiff</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>1.2.1</version>
-            <executions>
-              <execution>
-                <id>metadata</id>
-                <goals>
-                  <goal>java</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <mainClass>ome.files.performance.OMETIFFPerformance</mainClass>
-              <arguments>
-                <argument>${test.iterations}</argument>
-                <argument>${test.input}</argument>
-                <argument>${test.output}</argument>
-                <argument>${test.results}</argument>
-              </arguments>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,38 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>ometiff</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+            <executions>
+              <execution>
+                <id>metadata</id>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <mainClass>ome.files.performance.OMETIFFPerformance</mainClass>
+              <arguments>
+                <argument>${test.iterations}</argument>
+                <argument>${test.input}</argument>
+                <argument>${test.output}</argument>
+                <argument>${test.results}</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <repositories>

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -119,12 +119,16 @@ for %%T in (bbbc mitocheck tubhiswt) do (
     set input=unknown
     if [!test!] == [bbbc] (
         set input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff
+        set inputglob=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff
     )
     if [!test!] == [mitocheck] (
         set input=%DATA_DIR%\mitocheck\00001_01.ome.tiff
+        set inputglob=%DATA_DIR%\mitocheck\00001_01.ome.tiff
     )
     if [!test!] == [tubhiswt] (
         set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
+        set inputglob=
+        for /f "tokens=*" %%F in ('dir /b /a:-d "%DATA_DIR%\tubhiswt-4D\tubhiswt_*.tif"') do call set inputglob=%%inputglob%% "%%F"
     )
 
     cd %WORKSPACE%\source
@@ -136,9 +140,9 @@ for %%T in (bbbc mitocheck tubhiswt) do (
     )
 
     REM Run Java pixels performance tests
-    call scripts\pixels-performance-java %iterations% !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java.tsv exec:java
+    call scripts\pixels-performance-java %iterations% !inputglob! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java.tsv exec:java
     for /L %%I IN (1,1,!iterations!) do (
-        call scripts\pixels-performance-java 1 !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
+        call scripts\pixels-performance-java 1 !inputglob! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
     )
 
     REM Run Java ometiff performance tests
@@ -157,9 +161,9 @@ for %%T in (bbbc mitocheck tubhiswt) do (
     )
 
     REM Run C++ pixels performance tests
-    install\bin\pixels-performance %iterations% !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp.tsv
+    install\bin\pixels-performance %iterations% !inputglob! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp.tsv
     for /L %%I IN (1,1,!iterations!) do (
-        install\bin\pixels-performance 1 !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp-%%I.tsv
+        install\bin\pixels-performance 1 !inputglob! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp-%%I.tsv
     )
 
     REM Run C++ ometiff performance tests

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -134,21 +134,21 @@ for %%T in (bbbc mitocheck tubhiswt) do (
     cd %WORKSPACE%\source
 
     REM Run Java metadata performance tests
-    call scripts\metadata-performance-java %iterations% !input! %outdir%\!test!-java.ome.xml %resultsdir%\!test!-metadata-win-java.tsv exec:java
+    call scripts\metadata-performance-java %iterations% !input! %outdir%\!test!-java.ome.xml %resultsdir%\!test!-metadata-win-java.tsv
     for /L %%I IN (1,1,!iterations!) do (
-        call scripts\metadata-performance-java 1 !input! %outdir%\!test!-java.ome.xml %resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        call scripts\metadata-performance-java 1 !input! %outdir%\!test!-java.ome.xml %resultsdir%\!test!-metadata-win-java-%%I.tsv
     )
 
     REM Run Java pixels performance tests
-    call scripts\pixels-performance-java %iterations% !inputglob! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java.tsv exec:java
+    call scripts\pixels-performance-java %iterations% !inputglob! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java.tsv
     for /L %%I IN (1,1,!iterations!) do (
-        call scripts\pixels-performance-java 1 !inputglob! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
+        call scripts\pixels-performance-java 1 !inputglob! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java-%%I.tsv
     )
 
     REM Run Java ometiff performance tests
-    call scripts\ometiff-performance-java %iterations% !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-ometiffdata-win-java.tsv exec:java
+    call scripts\ometiff-performance-java %iterations% !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-ometiffdata-win-java.tsv
     for /L %%I IN (1,1,!iterations!) do (
-        call scripts\ometiff-performance-java 1 !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-ometiffdata-win-java-%%I.tsv exec:java
+        call scripts\ometiff-performance-java 1 !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-ometiffdata-win-java-%%I.tsv
     )
 
     REM Execute C++ performance tests

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -130,21 +130,21 @@ for %%T in (bbbc mitocheck tubhiswt) do (
     cd %WORKSPACE%\source
 
     REM Run Java metadata performance tests
-    call mvn -P metadata -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+    call scripts\metadata-performance-java %iterations% !input! %outdir%\!test!-java.ome.xml %resultsdir%\!test!-metadata-win-java.tsv exec:java
     for /L %%I IN (1,1,!iterations!) do (
-        call mvn -P metadata -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        call scripts\metadata-performance-java 1 !input! %outdir%\!test!-java.ome.xml %resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
     )
 
     REM Run Java pixels performance tests
-    call mvn -P pixels -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java.tsv exec:java
+    call scripts\pixels-performance-java %iterations% !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java.tsv exec:java
     for /L %%I IN (1,1,!iterations!) do (
-        call mvn -P pixels -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
+        call scripts\pixels-performance-java 1 !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
     )
 
     REM Run Java ometiff performance tests
-    call mvn -P ometiff -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-ometiffdata-win-java.tsv exec:java
+    call scripts\ometiff-performance-java %iterations% !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-ometiffdata-win-java.tsv exec:java
     for /L %%I IN (1,1,!iterations!) do (
-        call mvn -P ometiff -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-ometiffdata-win-java-%%I.tsv exec:java
+        call scripts\ometiff-performance-java 1 !input! %outdir%\!test!-java.ome.tiff %resultsdir%\!test!-ometiffdata-win-java-%%I.tsv exec:java
     )
 
     REM Execute C++ performance tests

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -141,6 +141,12 @@ for %%T in (bbbc mitocheck tubhiswt) do (
         call mvn -P pixels -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
     )
 
+    REM Run Java ometiff performance tests
+    call mvn -P ometiff -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-ometiffdata-win-java.tsv exec:java
+    for /L %%I IN (1,1,!iterations!) do (
+        call mvn -P ometiff -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-ometiffdata-win-java-%%I.tsv exec:java
+    )
+
     REM Execute C++ performance tests
     cd "%WORKSPACE%"
 
@@ -154,5 +160,11 @@ for %%T in (bbbc mitocheck tubhiswt) do (
     install\bin\pixels-performance %iterations% !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp.tsv
     for /L %%I IN (1,1,!iterations!) do (
         install\bin\pixels-performance 1 !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp-%%I.tsv
+    )
+
+    REM Run C++ ometiff performance tests
+    install\bin\ometiff-performance %iterations% !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-ometiffdata-win-cpp.tsv
+    for /L %%I IN (1,1,!iterations!) do (
+        install\bin\ometiff-performance 1 !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-ometiffdata-win-cpp-%%I.tsv
     )
 )

--- a/scripts/metadata-performance-java
+++ b/scripts/metadata-performance-java
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+exec java -classpath "target/classes:target/dependency/*" ome.files.performance.MetadataPerformance "$@"

--- a/scripts/metadata-performance-java.bat
+++ b/scripts/metadata-performance-java.bat
@@ -1,0 +1,3 @@
+@echo off
+
+java -classpath "target/classes;target/dependency/*" ome.files.performance.MetadataPerformance "$@"

--- a/scripts/metadata-performance-java.bat
+++ b/scripts/metadata-performance-java.bat
@@ -1,3 +1,11 @@
 @echo off
 
-java -classpath "target/classes;target/dependency/*" ome.files.performance.MetadataPerformance "$@"
+set params=%1
+:argloop
+shift
+if [%1]==[] goto afterargloop
+set params=%params% %1
+goto argloop
+:afterargloop
+
+java -classpath "target/classes;target/dependency/*" ome.files.performance.MetadataPerformance %params%

--- a/scripts/metadata-performance-java.bat
+++ b/scripts/metadata-performance-java.bat
@@ -8,4 +8,5 @@ set params=%params% %1
 goto argloop
 :afterargloop
 
+echo Running java -classpath "target/classes;target/dependency/*" ome.files.performance.MetadataPerformance %params%
 java -classpath "target/classes;target/dependency/*" ome.files.performance.MetadataPerformance %params%

--- a/scripts/ometiff-performance-java
+++ b/scripts/ometiff-performance-java
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+exec java -classpath "target/classes:target/dependency/*" ome.files.performance.OMETIFFPerformance "$@"

--- a/scripts/ometiff-performance-java.bat
+++ b/scripts/ometiff-performance-java.bat
@@ -1,3 +1,11 @@
 @echo off
 
-java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance "$@"
+set params=%1
+:argloop
+shift
+if [%1]==[] goto afterargloop
+set params=%params% %1
+goto argloop
+:afterargloop
+
+java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance %params%

--- a/scripts/ometiff-performance-java.bat
+++ b/scripts/ometiff-performance-java.bat
@@ -1,3 +1,3 @@
 @echo off
 
-exec java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance "$@"
+java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance "$@"

--- a/scripts/ometiff-performance-java.bat
+++ b/scripts/ometiff-performance-java.bat
@@ -1,0 +1,3 @@
+@echo off
+
+exec java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance "$@"

--- a/scripts/ometiff-performance-java.bat
+++ b/scripts/ometiff-performance-java.bat
@@ -8,4 +8,5 @@ set params=%params% %1
 goto argloop
 :afterargloop
 
+echo Running java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance %params%
 java -classpath "target/classes;target/dependency/*" ome.files.performance.OMETIFFPerformance %params%

--- a/scripts/pixels-performance-java
+++ b/scripts/pixels-performance-java
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+exec java -classpath "target/classes:target/dependency/*" ome.files.performance.PixelsPerformance "$@"

--- a/scripts/pixels-performance-java.bat
+++ b/scripts/pixels-performance-java.bat
@@ -1,0 +1,3 @@
+@echo off
+
+java -classpath "target/classes;target/dependency/*" ome.files.performance.PixelsPerformance "$@"

--- a/scripts/pixels-performance-java.bat
+++ b/scripts/pixels-performance-java.bat
@@ -8,4 +8,5 @@ set params=%params% %1
 goto argloop
 :afterargloop
 
+echo Running java -classpath "target/classes;target/dependency/*" ome.files.performance.PixelsPerformance %params%
 java -classpath "target/classes;target/dependency/*" ome.files.performance.PixelsPerformance %params%

--- a/scripts/pixels-performance-java.bat
+++ b/scripts/pixels-performance-java.bat
@@ -1,3 +1,11 @@
 @echo off
 
-java -classpath "target/classes;target/dependency/*" ome.files.performance.PixelsPerformance "$@"
+set params=%1
+:argloop
+shift
+if [%1]==[] goto afterargloop
+set params=%params% %1
+goto argloop
+:afterargloop
+
+java -classpath "target/classes;target/dependency/*" ome.files.performance.PixelsPerformance %params%

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -30,19 +30,19 @@ for test in bbbc mitocheck tubhiswt; do
 
     # Java tests
     (
-        mvn -P metadata -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+        scripts/metadata-performance-java ${iterations} "$input" ${outpath}/${test}-java.ome.xml ${resultpath}/${test}-metadata-linux-java.tsv exec:java
         for i in $(seq ${iterations}); do
-            mvn -P metadata -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+            scripts/metadata-performance-java 1 "$input" ${outpath}/${test}-java.ome.xml ${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
         done
 
-        mvn -P pixels -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java.tsv exec:java
+        scripts/pixels-performance-java ${iterations} "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-pixeldata-linux-java.tsv exec:java
         for i in $(seq ${iterations}); do
-            mvn -P pixels -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
+            scripts/pixels-performance-java 1 "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
         done
 
-        mvn -P ometiff -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-ometiffdata-linux-java.tsv exec:java
+        scripts/ometiff-performance-java ${iterations} "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-ometiffdata-linux-java.tsv exec:java
         for i in $(seq ${iterations}); do
-            mvn -P ometiff -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-ometiffdata-linux-java-${i}.tsv exec:java
+            scripts/ometiff-performance-java 1 "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-ometiffdata-linux-java-${i}.tsv exec:java
         done
     )
 

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -19,12 +19,15 @@ for test in bbbc mitocheck tubhiswt; do
     case "$test" in
         bbbc)
             input=${datapath}/BBBC/NIRHTa-001.ome.tiff
+            inputglob=${datapath}/BBBC/NIRHTa-001.ome.tiff
         ;;
         mitocheck)
             input=${datapath}/mitocheck/00001_01.ome.tiff
+            inputglob=${datapath}/mitocheck/00001_01.ome.tiff
         ;;
         tubhiswt)
             input=${datapath}/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif
+            input=${datapath}/tubhiswt-4D/*.tif
         ;;
     esac
 
@@ -35,9 +38,9 @@ for test in bbbc mitocheck tubhiswt; do
             scripts/metadata-performance-java 1 "$input" ${outpath}/${test}-java.ome.xml ${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
         done
 
-        scripts/pixels-performance-java ${iterations} "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-pixeldata-linux-java.tsv exec:java
+        scripts/pixels-performance-java ${iterations} $inputglob ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-pixeldata-linux-java.tsv exec:java
         for i in $(seq ${iterations}); do
-            scripts/pixels-performance-java 1 "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
+            scripts/pixels-performance-java 1 $inputglob ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
         done
 
         scripts/ometiff-performance-java ${iterations} "$input" ${outpath}/${test}-java.ome.tiff ${resultpath}/${test}-ometiffdata-linux-java.tsv exec:java
@@ -53,9 +56,9 @@ for test in bbbc mitocheck tubhiswt; do
             ${binpath}/metadata-performance 1 "$input" ${outpath}/${test}-cpp.ome.xml ${resultpath}/${test}-metadata-linux-cpp-${i}.tsv
         done
 
-        ${binpath}/pixels-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp.tsv
+        ${binpath}/pixels-performance ${iterations} $inputglob ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp.tsv
         for i in $(seq ${iterations}); do
-            ${binpath}/pixels-performance 1 "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp-${i}.tsv
+            ${binpath}/pixels-performance 1 $inputglob ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp-${i}.tsv
         done
 
         ${binpath}/ometiff-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-ometiffdata-linux-cpp.tsv
@@ -78,9 +81,9 @@ for test in bbbc mitocheck tubhiswt; do
         if [ "$test" == "bbbc" ]; then
             jace_iterations=6
         fi
-        ${binpath}/pixels-performance-jace ${jace_iterations} "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-pixeldata-linux-jace.tsv
+        ${binpath}/pixels-performance-jace ${jace_iterations} $inputglob ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-pixeldata-linux-jace.tsv
         for i in $(seq ${jace_iterations}); do
-            ${binpath}/pixels-performance-jace 1 "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-pixeldata-linux-jace-${i}.tsv
+            ${binpath}/pixels-performance-jace 1 $inputglob ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-pixeldata-linux-jace-${i}.tsv
         done
         ${binpath}/ometiff-performance-jace ${jace_iterations} "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-ometiffdata-linux-jace.tsv
         for i in $(seq ${jace_iterations}); do

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -39,6 +39,11 @@ for test in bbbc mitocheck tubhiswt; do
         for i in $(seq ${iterations}); do
             mvn -P pixels -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
         done
+
+        mvn -P ometiff -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-ometiffdata-linux-java.tsv exec:java
+        for i in $(seq ${iterations}); do
+            mvn -P ometiff -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-ometiffdata-linux-java-${i}.tsv exec:java
+        done
     )
 
     # C++ tests
@@ -51,6 +56,11 @@ for test in bbbc mitocheck tubhiswt; do
         ${binpath}/pixels-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp.tsv
         for i in $(seq ${iterations}); do
             ${binpath}/pixels-performance 1 "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp-${i}.tsv
+        done
+
+        ${binpath}/ometiff-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-ometiffdata-linux-cpp.tsv
+        for i in $(seq ${iterations}); do
+            ${binpath}/ometiff-performance 1 "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-ometiffdata-linux-cpp-${i}.tsv
         done
     )
 
@@ -71,6 +81,10 @@ for test in bbbc mitocheck tubhiswt; do
         ${binpath}/pixels-performance-jace ${jace_iterations} "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-pixeldata-linux-jace.tsv
         for i in $(seq ${jace_iterations}); do
             ${binpath}/pixels-performance-jace 1 "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-pixeldata-linux-jace-${i}.tsv
+        done
+        ${binpath}/ometiff-performance-jace ${jace_iterations} "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-ometiffdata-linux-jace.tsv
+        for i in $(seq ${jace_iterations}); do
+            ${binpath}/ometiff-performance-jace 1 "$input" ${outpath}/${test}-jace.ome.tiff ${resultpath}/${test}-ometiffdata-linux-jace-${i}.tsv
         done
     )
 done

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -54,6 +54,15 @@ target_link_libraries(pixels-performance
   Boost::disable_autolinking
   Boost::dynamic_linking)
 
-install(TARGETS metadata-performance pixels-performance
+add_executable(ometiff-performance ometiff-performance.cpp result.cpp result.h)
+target_link_libraries(ometiff-performance
+  OME::Files
+  Boost::boost
+  Boost::chrono
+  Boost::filesystem
+  Boost::disable_autolinking
+  Boost::dynamic_linking)
+
+install(TARGETS metadata-performance pixels-performance ometiff-performance
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT "runtime")

--- a/src/main/cpp/pixels-performance.cpp
+++ b/src/main/cpp/pixels-performance.cpp
@@ -49,8 +49,8 @@
 
 #include <ome/files/FormatException.h>
 #include <ome/files/VariantPixelBuffer.h>
-#include <ome/files/in/OMETIFFReader.h>
-#include <ome/files/out/OMETIFFWriter.h>
+#include <ome/files/in/MinimalTIFFReader.h>
+#include <ome/files/out/MinimalTIFFWriter.h>
 
 #include <ome/xml/meta/OMEXMLMetadata.h>
 
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 
           {
             std::cout << "pass " << i << ": read init..." << std::flush;
-            ome::files::in::OMETIFFReader reader;
+            ome::files::in::MinimalTIFFReader reader;
             reader.setMetadataStore(store);
             reader.setId(infile);
             std::cout << "done\n" << std::flush;
@@ -148,10 +148,10 @@ int main(int argc, char *argv[])
 
           {
             std::cout << "pass " << i << ": write init..." << std::flush;
-            std::unique_ptr<ome::files::FormatWriter> writer = std::make_unique<ome::files::out::OMETIFFWriter>();
+            std::unique_ptr<ome::files::FormatWriter> writer = std::make_unique<ome::files::out::MinimalTIFFWriter>();
             writer->setMetadataRetrieve(retrieve);
             writer->setInterleaved(interleaved.at(0));
-            dynamic_cast<ome::files::out::OMETIFFWriter &>(*writer.get()).setBigTIFF(true);
+            dynamic_cast<ome::files::out::MinimalTIFFWriter &>(*writer.get()).setBigTIFF(true);
             writer->setId(outfile);
             std::cout << "done\n" << std::flush;
 

--- a/src/main/cpp/result.cpp
+++ b/src/main/cpp/result.cpp
@@ -64,3 +64,36 @@ result(std::ostream& os,
      << boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().system // process system time
      << '\n';
 }
+
+void
+result(std::ostream& os,
+       const std::string& testname,
+       const boost::filesystem::path& testfile,
+       const std::vector<timepoint>& starts,
+       const std::vector<timepoint>& ends)
+{
+  using rettype = decltype(boost::chrono::duration_cast<cpu_clock_milliseconds>(ends[0].process - starts[0].process).count().real);
+  rettype real = 0, user = 0, system = 0;
+
+  for (std::vector<timepoint>::size_type i = 0; i < starts.size(); ++i)
+    {
+      const timepoint& start = starts.at(i);
+      const timepoint& end = ends.at(i);
+      real += boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().real;
+      user += boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().user;
+      system += boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().system;
+    }
+
+  os << "C++"
+     << '\t'
+     << testname
+     << '\t'
+     << testfile.filename().string()
+     << '\t'
+     << real // process real time
+     << '\t'
+     << user // process user time
+     << '\t'
+     << system // process system time
+     << '\n';
+}

--- a/src/main/cpp/result.h
+++ b/src/main/cpp/result.h
@@ -38,6 +38,9 @@
 
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include <boost/chrono/process_cpu_clocks.hpp>
 #include <boost/chrono/system_clocks.hpp>
 #include <boost/chrono/thread_clock.hpp>
@@ -90,6 +93,25 @@ result(std::ostream& os,
        const boost::filesystem::path& testfile,
        const timepoint& start,
        const timepoint& end);
+
+/**
+ * Output TSV test result (accumulate readings).
+ *
+ * The time duration for each recorded timepoint will be output with
+ * millisecond precision.
+ *
+ * @param os the stream to use.
+ * @param testname the name of the test.
+ * @param testfile the input filename of the test data.
+ * @param starts the start timepoints.
+ * @param ends the endm timepoints.
+ */
+void
+result(std::ostream& os,
+       const std::string& testname,
+       const boost::filesystem::path& testfile,
+       const std::vector<timepoint>& starts,
+       const std::vector<timepoint>& ends);
 
 /*
  * Local Variables:

--- a/src/main/jace/CMakeLists.txt
+++ b/src/main/jace/CMakeLists.txt
@@ -175,7 +175,25 @@ if(BioFormatsJACE_FOUND AND JNI_FOUND)
     ${JNI_LIBRARIES}
     ${CMAKE_DL_LIBS})
 
-  install(TARGETS metadata-performance-jace pixels-performance-jace
+  add_executable(ometiff-performance-jace
+    ometiff-performance.cpp
+    result.cpp
+    result.h
+    ${jace_sources}
+    ${jace_tools})
+  target_link_libraries(ometiff-performance-jace
+    BioFormatsJACE::BioFormatsJACE
+    Threads::Threads
+    Boost::filesystem
+    Boost::thread
+    Boost::disable_autolinking
+    Boost::dynamic_linking
+    ${JNI_LIBRARIES}
+    ${CMAKE_DL_LIBS})
+
+  install(TARGETS metadata-performance-jace
+                  pixels-performance-jace
+                  ometiff-performance-jace
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT "runtime")
 

--- a/src/main/jace/ometiff-performance.cpp
+++ b/src/main/jace/ometiff-performance.cpp
@@ -66,7 +66,8 @@ using loci::formats::FormatException;
 using loci::formats::FormatReader;
 using loci::formats::FormatWriter;
 using loci::formats::MetadataTools;
-using loci::formats::in::MinimalTiffReader;
+using loci::formats::in::OMETiffReader;
+using loci::formats::out::OMETiffWriter;
 using loci::formats::out::TiffWriter;
 using loci::formats::meta::IMetadata;
 using loci::formats::meta::MetadataRetrieve;
@@ -110,8 +111,8 @@ int main(int argc, char *argv[])
 
           {
             std::cout << "pass " << i << ": read init..." << std::flush;
-            MinimalTiffReader tiffreader;
-            FormatReader reader = java_cast<FormatReader>(tiffreader);
+            OMETiffReader ometiffreader;
+            FormatReader reader = java_cast<FormatReader>(ometiffreader);
             reader.setMetadataStore(meta);
             reader.setId(infile.string());
             std::cout << "done\n" << std::flush;
@@ -143,9 +144,9 @@ int main(int argc, char *argv[])
 
           timepoint read_end;
 
-          result(results, "pixeldata.read", infile, read_start, read_end);
-          result(results, "pixeldata.read.init", infile, read_start, read_init);
-          result(results, "pixeldata.read.pixels", infile, read_init, read_end);
+          result(results, "ometiffdata.read", infile, read_start, read_end);
+          result(results, "ometiffdata.read.init", infile, read_start, read_init);
+          result(results, "ometiffdata.read.pixels", infile, read_init, read_end);
 
           // The Java writer doesn't automatically truncate the output file.
           if(boost::filesystem::exists(outfile))
@@ -157,11 +158,11 @@ int main(int argc, char *argv[])
 
           {
             std::cout << "pass " << i << ": write init..." << std::flush;
-            TiffWriter tiffwriter;
-            FormatWriter writer = java_cast<FormatWriter>(tiffwriter);
+            OMETiffWriter ometiffwriter;
+            FormatWriter writer = java_cast<FormatWriter>(ometiffwriter);
             writer.setMetadataRetrieve(meta);
             writer.setInterleaved(true);
-            tiffwriter.setBigTiff(true);
+            ometiffwriter.setBigTiff(true);
             writer.setId(outfile.string());
             std::cout << "done\n" << std::flush;
 
@@ -188,6 +189,7 @@ int main(int argc, char *argv[])
                     }
                     ifd.putIFDValue(IFD::ROWS_PER_STRIP(), static_cast<::jace::proxy::types::JInt>(rows));
                     ByteArray& buf = *(planes.at(plane));
+                    TiffWriter tiffwriter = java_cast<TiffWriter>(ometiffwriter);
                     tiffwriter.saveBytes(plane, buf, ifd);
                     std::cout << '.' << std::flush;
                   }
@@ -200,10 +202,10 @@ int main(int argc, char *argv[])
 
           timepoint write_end;
 
-          result(results, "pixeldata.write", infile, write_start, write_end);
-          result(results, "pixeldata.write.init", infile, write_start, write_init);
-          result(results, "pixeldata.write.pixels", infile, write_init, close_start);
-          result(results, "pixeldata.write.close", infile, close_start, write_end);
+          result(results, "ometiffdata.write", infile, write_start, write_end);
+          result(results, "ometiffdata.write.init", infile, write_start, write_init);
+          result(results, "ometiffdata.write.pixels", infile, write_init, close_start);
+          result(results, "ometiffdata.write.close", infile, close_start, write_end);
         }
       return 0;
     }

--- a/src/main/jace/result.cpp
+++ b/src/main/jace/result.cpp
@@ -41,7 +41,7 @@
 void
 result_header(std::ostream& os)
 {
-  os << "test.lang\ttest.name\ttest.file\tsystem.time\tthread.time\tproc.real\tproc.user\tproc.system\n";
+  os << "test.lang\ttest.name\ttest.file\tproc.real\tproc.user\tproc.system\n";
 }
 
 void
@@ -57,14 +57,43 @@ result(std::ostream& os,
      << '\t'
      << testfile.filename().string()
      << '\t'
-     << boost::chrono::duration_cast<boost::chrono::milliseconds>(end.system - start.system).count() // system time
-     << '\t'
-     << boost::chrono::duration_cast<boost::chrono::milliseconds>(end.thread - start.thread).count() // thread time
-     << '\t'
      << boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().real // process real time
      << '\t'
      << boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().user // process user time
      << '\t'
      << boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().system // process system time
+     << '\n';
+}
+
+void
+result(std::ostream& os,
+       const std::string& testname,
+       const boost::filesystem::path& testfile,
+       const std::vector<timepoint>& starts,
+       const std::vector<timepoint>& ends)
+{
+  using rettype = decltype(boost::chrono::duration_cast<cpu_clock_milliseconds>(ends[0].process - starts[0].process).count().real);
+  rettype real = 0, user = 0, system = 0;
+
+  for (std::vector<timepoint>::size_type i = 0; i < starts.size(); ++i)
+    {
+      const timepoint& start = starts.at(i);
+      const timepoint& end = ends.at(i);
+      real += boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().real;
+      user += boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().user;
+      system += boost::chrono::duration_cast<cpu_clock_milliseconds>(end.process - start.process).count().system;
+    }
+
+  os << "C++"
+     << '\t'
+     << testname
+     << '\t'
+     << testfile.filename().string()
+     << '\t'
+     << real // process real time
+     << '\t'
+     << user // process user time
+     << '\t'
+     << system // process system time
      << '\n';
 }

--- a/src/main/jace/result.h
+++ b/src/main/jace/result.h
@@ -38,6 +38,9 @@
 
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include <boost/chrono/process_cpu_clocks.hpp>
 #include <boost/chrono/system_clocks.hpp>
 #include <boost/chrono/thread_clock.hpp>
@@ -57,14 +60,10 @@ typedef boost::chrono::duration<boost::chrono::process_times<boost::chrono::mill
  */
 struct timepoint
 {
-timepoint():
-  system(boost::chrono::high_resolution_clock::now()),
-    thread(boost::chrono::thread_clock::now()),
+  timepoint():
     process(boost::chrono::process_cpu_clock::now())
   {}
 
-  boost::chrono::high_resolution_clock::time_point system;
-  boost::chrono::thread_clock::time_point thread;
   boost::chrono::process_cpu_clock::time_point process;
 };
 
@@ -94,6 +93,25 @@ result(std::ostream& os,
        const boost::filesystem::path& testfile,
        const timepoint& start,
        const timepoint& end);
+
+/**
+ * Output TSV test result (accumulate readings).
+ *
+ * The time duration for each recorded timepoint will be output with
+ * millisecond precision.
+ *
+ * @param os the stream to use.
+ * @param testname the name of the test.
+ * @param testfile the input filename of the test data.
+ * @param starts the start timepoints.
+ * @param ends the endm timepoints.
+ */
+void
+result(std::ostream& os,
+       const std::string& testname,
+       const boost::filesystem::path& testfile,
+       const std::vector<timepoint>& starts,
+       const std::vector<timepoint>& ends);
 
 /*
  * Local Variables:

--- a/src/main/java/ome/files/performance/OMETIFFPerformance.java
+++ b/src/main/java/ome/files/performance/OMETIFFPerformance.java
@@ -134,56 +134,56 @@ public final class OMETIFFPerformance {
         Timepoint write_init = null;
         Timepoint close_start = null;
 
-          {
-            System.out.print("pass " + i + ": write init...");
-            System.out.flush();
-            FormatWriter writer = new OMETiffWriter();
-            writer.setMetadataRetrieve(meta);
-            writer.setWriteSequentially(true);
-            writer.setInterleaved(true);
-            ((OMETiffWriter)writer).setBigTiff(true);
-            writer.setId(outfile.toString());
-            System.out.println("done");
-            System.out.flush();
+        {
+          System.out.print("pass " + i + ": write init...");
+          System.out.flush();
+          FormatWriter writer = new OMETiffWriter();
+          writer.setMetadataRetrieve(meta);
+          writer.setWriteSequentially(true);
+          writer.setInterleaved(true);
+          ((OMETiffWriter)writer).setBigTiff(true);
+          writer.setId(outfile.toString());
+          System.out.println("done");
+          System.out.flush();
 
-            write_init = new Timepoint();
+          write_init = new Timepoint();
 
-            for (int series = 0; series < pixels.size(); ++series)
-              {
-                System.out.print("pass " + i + ": write series " + series + ": ");
-                System.out.flush();
-                writer.setInterleaved(true);
-                writer.setSeries(series);
+          for (int series = 0; series < pixels.size(); ++series)
+            {
+              System.out.print("pass " + i + ": write series " + series + ": ");
+              System.out.flush();
+              writer.setInterleaved(true);
+              writer.setSeries(series);
 
-                List<byte[]> planes = pixels.get(series);
+              List<byte[]> planes = pixels.get(series);
 
-                for (int plane = 0; plane < planes.size(); ++plane)
-                  {
-                    int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
-                    IFD ifd = new IFD();
-                    int rows = 65536 / sizeX;
-                    if (rows < 1) {
-                      rows = 1;
-                    }
-                    ifd.put(IFD.ROWS_PER_STRIP, rows);
-                    byte[] data = planes.get(plane);
-                    ((TiffWriter) writer).saveBytes(plane, data, ifd);
-                    System.out.print(".");
-                    System.out.flush();
+              for (int plane = 0; plane < planes.size(); ++plane)
+                {
+                  int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
+                  IFD ifd = new IFD();
+                  int rows = 65536 / sizeX;
+                  if (rows < 1) {
+                    rows = 1;
                   }
-                System.out.println("done");
-                System.out.flush();
-              }
-            close_start = new Timepoint();
-            writer.close();
-          }
+                  ifd.put(IFD.ROWS_PER_STRIP, rows);
+                  byte[] data = planes.get(plane);
+                  ((TiffWriter) writer).saveBytes(plane, data, ifd);
+                  System.out.print(".");
+                  System.out.flush();
+                }
+              System.out.println("done");
+              System.out.flush();
+            }
+          close_start = new Timepoint();
+          writer.close();
+        }
 
-          Timepoint write_end = new Timepoint();
+        Timepoint write_end = new Timepoint();
 
-          result.add("ometiffdata.write", infile, write_start, write_end);
-          result.add("ometiffdata.write.init", infile, write_start, write_init);
-          result.add("ometiffdata.write.pixels", infile, write_init, close_start);
-          result.add("ometiffdata.write.close", infile, close_start, write_end);
+        result.add("ometiffdata.write", infile, write_start, write_end);
+        result.add("ometiffdata.write.init", infile, write_start, write_init);
+        result.add("ometiffdata.write.pixels", infile, write_init, close_start);
+        result.add("ometiffdata.write.close", infile, close_start, write_end);
       }
 
       result.close();

--- a/src/main/java/ome/files/performance/OMETIFFPerformance.java
+++ b/src/main/java/ome/files/performance/OMETIFFPerformance.java
@@ -53,7 +53,8 @@ import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.ome.OMEXMLMetadataImpl;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
-import loci.formats.in.MinimalTiffReader;
+import loci.formats.in.OMETiffReader;
+import loci.formats.out.OMETiffWriter;
 import loci.formats.out.TiffWriter;
 import loci.formats.FormatReader;
 import loci.formats.FormatWriter;
@@ -61,7 +62,7 @@ import loci.formats.FormatWriter;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.TiffParser;
 
-public final class PixelsPerformance {
+public final class OMETIFFPerformance {
 
   public static void main(String[] args) {
     if (args.length != 4)
@@ -93,7 +94,7 @@ public final class PixelsPerformance {
         {
           System.out.print("pass " + i + ": read init...");
           System.out.flush();
-          FormatReader reader = new MinimalTiffReader();
+          FormatReader reader = new OMETiffReader();
           reader.setMetadataStore(meta);
           reader.setId(infile.toString());
           System.out.println("done");
@@ -123,9 +124,9 @@ public final class PixelsPerformance {
 
         Timepoint read_end = new Timepoint();
 
-        result.add("pixeldata.read", infile, read_start, read_end);
-        result.add("pixeldata.read.init", infile, read_start, read_init);
-        result.add("pixeldata.read.pixels", infile, read_init, read_end);
+        result.add("ometiffdata.read", infile, read_start, read_end);
+        result.add("ometiffdata.read.init", infile, read_start, read_init);
+        result.add("ometiffdata.read.pixels", infile, read_init, read_end);
 
         Files.deleteIfExists(outfile);
 
@@ -136,11 +137,11 @@ public final class PixelsPerformance {
           {
             System.out.print("pass " + i + ": write init...");
             System.out.flush();
-            FormatWriter writer = new TiffWriter();
+            FormatWriter writer = new OMETiffWriter();
             writer.setMetadataRetrieve(meta);
             writer.setWriteSequentially(true);
             writer.setInterleaved(true);
-            ((TiffWriter)writer).setBigTiff(true);
+            ((OMETiffWriter)writer).setBigTiff(true);
             writer.setId(outfile.toString());
             System.out.println("done");
             System.out.flush();
@@ -179,10 +180,10 @@ public final class PixelsPerformance {
 
           Timepoint write_end = new Timepoint();
 
-          result.add("pixeldata.write", infile, write_start, write_end);
-          result.add("pixeldata.write.init", infile, write_start, write_init);
-          result.add("pixeldata.write.pixels", infile, write_init, close_start);
-          result.add("pixeldata.write.close", infile, close_start, write_end);
+          result.add("ometiffdata.write", infile, write_start, write_end);
+          result.add("ometiffdata.write.init", infile, write_start, write_init);
+          result.add("ometiffdata.write.pixels", infile, write_init, close_start);
+          result.add("ometiffdata.write.close", infile, close_start, write_end);
       }
 
       result.close();

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -133,56 +133,56 @@ public final class PixelsPerformance {
         Timepoint write_init = null;
         Timepoint close_start = null;
 
-          {
-            System.out.print("pass " + i + ": write init...");
-            System.out.flush();
-            FormatWriter writer = new TiffWriter();
-            writer.setMetadataRetrieve(meta);
-            writer.setWriteSequentially(true);
-            writer.setInterleaved(true);
-            ((TiffWriter)writer).setBigTiff(true);
-            writer.setId(outfile.toString());
-            System.out.println("done");
-            System.out.flush();
+        {
+          System.out.print("pass " + i + ": write init...");
+          System.out.flush();
+          FormatWriter writer = new TiffWriter();
+          writer.setMetadataRetrieve(meta);
+          writer.setWriteSequentially(true);
+          writer.setInterleaved(true);
+          ((TiffWriter)writer).setBigTiff(true);
+          writer.setId(outfile.toString());
+          System.out.println("done");
+          System.out.flush();
 
-            write_init = new Timepoint();
+          write_init = new Timepoint();
 
-            for (int series = 0; series < pixels.size(); ++series)
-              {
-                System.out.print("pass " + i + ": write series " + series + ": ");
-                System.out.flush();
-                writer.setInterleaved(true);
-                writer.setSeries(series);
+          for (int series = 0; series < pixels.size(); ++series)
+            {
+              System.out.print("pass " + i + ": write series " + series + ": ");
+              System.out.flush();
+              writer.setInterleaved(true);
+              writer.setSeries(series);
 
-                List<byte[]> planes = pixels.get(series);
+              List<byte[]> planes = pixels.get(series);
 
-                for (int plane = 0; plane < planes.size(); ++plane)
-                  {
-                    int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
-                    IFD ifd = new IFD();
-                    int rows = 65536 / sizeX;
-                    if (rows < 1) {
-                      rows = 1;
-                    }
-                    ifd.put(IFD.ROWS_PER_STRIP, rows);
-                    byte[] data = planes.get(plane);
-                    ((TiffWriter) writer).saveBytes(plane, data, ifd);
-                    System.out.print(".");
-                    System.out.flush();
+              for (int plane = 0; plane < planes.size(); ++plane)
+                {
+                  int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
+                  IFD ifd = new IFD();
+                  int rows = 65536 / sizeX;
+                  if (rows < 1) {
+                    rows = 1;
                   }
-                System.out.println("done");
-                System.out.flush();
-              }
-            close_start = new Timepoint();
-            writer.close();
-          }
+                  ifd.put(IFD.ROWS_PER_STRIP, rows);
+                  byte[] data = planes.get(plane);
+                  ((TiffWriter) writer).saveBytes(plane, data, ifd);
+                  System.out.print(".");
+                  System.out.flush();
+                }
+              System.out.println("done");
+              System.out.flush();
+            }
+          close_start = new Timepoint();
+          writer.close();
+        }
 
-          Timepoint write_end = new Timepoint();
+        Timepoint write_end = new Timepoint();
 
-          result.add("pixeldata.write", infile, write_start, write_end);
-          result.add("pixeldata.write.init", infile, write_start, write_init);
-          result.add("pixeldata.write.pixels", infile, write_init, close_start);
-          result.add("pixeldata.write.close", infile, close_start, write_end);
+        result.add("pixeldata.write", infile, write_start, write_end);
+        result.add("pixeldata.write.init", infile, write_start, write_init);
+        result.add("pixeldata.write.pixels", infile, write_init, close_start);
+        result.add("pixeldata.write.close", infile, close_start, write_end);
       }
 
       result.close();

--- a/src/main/java/ome/files/performance/PixelsPerformance.java
+++ b/src/main/java/ome/files/performance/PixelsPerformance.java
@@ -64,7 +64,7 @@ import loci.formats.tiff.TiffParser;
 public final class PixelsPerformance {
 
   public static void main(String[] args) {
-    if (args.length != 4)
+    if (args.length < 4)
       {
         System.out.println("Usage: MetadataPerformance iterations inputfile outputfile resultfile\n");
         System.exit(1);
@@ -74,9 +74,13 @@ public final class PixelsPerformance {
 
     try {
       int iterations = Integer.parseInt(args[0]);
-      Path infile = Paths.get(args[1]);
-      Path outfile = Paths.get(args[2]);
-      Path resultfile = Paths.get(args[3]);
+      List<Path> infiles = new ArrayList<Path>();
+      for(int i = 1; i < args.length-2; i++)
+        {
+          infiles.add(Paths.get(args[i]));
+        }
+      Path outfile = Paths.get(args[args.length-2]);
+      Path resultfile = Paths.get(args[args.length-1]);
 
       ServiceFactory factory = new ServiceFactory();
       OMEXMLService service = factory.getInstance(OMEXMLService.class);
@@ -84,105 +88,112 @@ public final class PixelsPerformance {
       result = new Result(resultfile);
 
       for(int i = 0; i < iterations; i++) {
-        OMEXMLMetadata meta = new OMEXMLMetadataImpl();
-        List<List<byte[]>> pixels = new ArrayList();
+        List<Timepoint> read_start = new ArrayList<Timepoint>();
+        List<Timepoint> read_init = new ArrayList<Timepoint>();
+        List<Timepoint> read_end = new ArrayList<Timepoint>();
+        List<Timepoint> write_start = new ArrayList<Timepoint>();
+        List<Timepoint> write_init = new ArrayList<Timepoint>();
+        List<Timepoint> write_close_start = new ArrayList<Timepoint>();
+        List<Timepoint> write_end = new ArrayList<Timepoint>();
 
-        Timepoint read_start = new Timepoint();
-        Timepoint read_init = null;
+        for(int j = 0; j < infiles.size(); ++j) {
+          Path infile = infiles.get(j);
 
-        {
-          System.out.print("pass " + i + ": read init...");
-          System.out.flush();
-          FormatReader reader = new MinimalTiffReader();
-          reader.setMetadataStore(meta);
-          reader.setId(infile.toString());
-          System.out.println("done");
-          System.out.flush();
+          OMEXMLMetadata meta = new OMEXMLMetadataImpl();
+          List<List<byte[]>> pixels = new ArrayList();
 
-          read_init = new Timepoint();
-
-          for (int series = 0; series <reader.getSeriesCount(); ++series) {
-            System.out.print("pass " + i + ": read series " + series + ": ");
+          read_start.add(new Timepoint());
+          {
+            System.out.print("pass " + i + ": read init...");
             System.out.flush();
-            reader.setSeries(series);
-
-            List<byte[]> planes = new ArrayList();
-            pixels.add(planes);
-
-            for (int plane = 0; plane < reader.getImageCount(); ++plane) {
-              byte[] data = reader.openBytes(plane);
-              planes.add(data);
-              System.out.print(".");
-              System.out.flush();
-            }
+            FormatReader reader = new MinimalTiffReader();
+            reader.setMetadataStore(meta);
+            reader.setId(infile.toString());
             System.out.println("done");
             System.out.flush();
-          }
-          reader.close();
-        }
 
-        Timepoint read_end = new Timepoint();
+            read_init.add(new Timepoint());
 
-        result.add("pixeldata.read", infile, read_start, read_end);
-        result.add("pixeldata.read.init", infile, read_start, read_init);
-        result.add("pixeldata.read.pixels", infile, read_init, read_end);
-
-        Files.deleteIfExists(outfile);
-
-        Timepoint write_start = new Timepoint();
-        Timepoint write_init = null;
-        Timepoint close_start = null;
-
-        {
-          System.out.print("pass " + i + ": write init...");
-          System.out.flush();
-          FormatWriter writer = new TiffWriter();
-          writer.setMetadataRetrieve(meta);
-          writer.setWriteSequentially(true);
-          writer.setInterleaved(true);
-          ((TiffWriter)writer).setBigTiff(true);
-          writer.setId(outfile.toString());
-          System.out.println("done");
-          System.out.flush();
-
-          write_init = new Timepoint();
-
-          for (int series = 0; series < pixels.size(); ++series)
-            {
-              System.out.print("pass " + i + ": write series " + series + ": ");
+            for (int series = 0; series <reader.getSeriesCount(); ++series) {
+              System.out.print("pass " + i + ": read series " + series + ": ");
               System.out.flush();
-              writer.setInterleaved(true);
-              writer.setSeries(series);
+              reader.setSeries(series);
 
-              List<byte[]> planes = pixels.get(series);
+              List<byte[]> planes = new ArrayList();
+              pixels.add(planes);
 
-              for (int plane = 0; plane < planes.size(); ++plane)
-                {
-                  int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
-                  IFD ifd = new IFD();
-                  int rows = 65536 / sizeX;
-                  if (rows < 1) {
-                    rows = 1;
-                  }
-                  ifd.put(IFD.ROWS_PER_STRIP, rows);
-                  byte[] data = planes.get(plane);
-                  ((TiffWriter) writer).saveBytes(plane, data, ifd);
-                  System.out.print(".");
-                  System.out.flush();
-                }
+              for (int plane = 0; plane < reader.getImageCount(); ++plane) {
+                byte[] data = reader.openBytes(plane);
+                planes.add(data);
+                System.out.print(".");
+                System.out.flush();
+              }
               System.out.println("done");
               System.out.flush();
             }
-          close_start = new Timepoint();
-          writer.close();
+            reader.close();
+          }
+
+          read_end.add(new Timepoint());
+
+          Files.deleteIfExists(outfile);
+
+          write_start.add(new Timepoint());
+
+          {
+            System.out.print("pass " + i + ": write init...");
+            System.out.flush();
+            FormatWriter writer = new TiffWriter();
+            writer.setMetadataRetrieve(meta);
+            writer.setWriteSequentially(true);
+            writer.setInterleaved(true);
+            ((TiffWriter)writer).setBigTiff(true);
+            writer.setId(outfile.toString());
+            System.out.println("done");
+            System.out.flush();
+
+            write_init.add(new Timepoint());
+
+            for (int series = 0; series < pixels.size(); ++series)
+              {
+                System.out.print("pass " + i + ": write series " + series + ": ");
+                System.out.flush();
+                writer.setInterleaved(true);
+                writer.setSeries(series);
+
+                List<byte[]> planes = pixels.get(series);
+
+                for (int plane = 0; plane < planes.size(); ++plane)
+                  {
+                    int sizeX = meta.getPixelsSizeX(series).getValue().intValue();
+                    IFD ifd = new IFD();
+                    int rows = 65536 / sizeX;
+                    if (rows < 1) {
+                      rows = 1;
+                    }
+                    ifd.put(IFD.ROWS_PER_STRIP, rows);
+                    byte[] data = planes.get(plane);
+                    ((TiffWriter)writer).saveBytes(plane, data, ifd);
+                    System.out.print(".");
+                    System.out.flush();
+                  }
+                System.out.println("done");
+                System.out.flush();
+              }
+            write_close_start.add(new Timepoint());
+            writer.close();
+          }
+
+          write_end.add(new Timepoint());
         }
 
-        Timepoint write_end = new Timepoint();
-
-        result.add("pixeldata.write", infile, write_start, write_end);
-        result.add("pixeldata.write.init", infile, write_start, write_init);
-        result.add("pixeldata.write.pixels", infile, write_init, close_start);
-        result.add("pixeldata.write.close", infile, close_start, write_end);
+        result.add("pixeldata.read", infiles.get(0), read_start, read_end);
+        result.add("pixeldata.read.init", infiles.get(0), read_start, read_init);
+        result.add("pixeldata.read.pixels", infiles.get(0), read_init, read_end);
+        result.add("pixeldata.write", infiles.get(0), write_start, write_end);
+        result.add("pixeldata.write.init", infiles.get(0), write_start, write_init);
+        result.add("pixeldata.write.pixels", infiles.get(0), write_init, write_close_start);
+        result.add("pixeldata.write.close", infiles.get(0), write_close_start, write_end);
       }
 
       result.close();

--- a/src/main/java/ome/files/performance/Result.java
+++ b/src/main/java/ome/files/performance/Result.java
@@ -36,6 +36,7 @@ import java.io.Writer;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.util.List;
 
 class Result {
   private Writer writer;
@@ -57,6 +58,26 @@ class Result {
                    (end.cpu-start.cpu)/1000000 + "\t" +
                    (end.user-start.user)/1000000 + "\t" +
                    (end.system-start.system)/1000000);
+
+  }
+
+  void add(String testname,
+           Path testfile,
+           List<Timepoint> start,
+           List<Timepoint> end) {
+    long real = 0, cpu = 0, user = 0, system = 0;
+    for(int i = 0; i < start.size(); i++) {
+      real += (end.get(i).real-start.get(i).real);
+      cpu += (end.get(i).cpu-start.get(i).cpu);
+      user += (end.get(i).user-start.get(i).user);
+      system += (end.get(i).system-start.get(i).system);
+    }
+    output.println("Java\t" + testname + "\t" +
+                   testfile.getFileName().toString() + "\t" +
+                   real/1000000 + "\t" +
+                   cpu/1000000 + "\t" +
+                   user/1000000 + "\t" +
+                   system/1000000);
 
   }
 


### PR DESCRIPTION
Add minimal tiff tests to test pixels only.  Avoids any timing ambiguity with the OME-TIFF writer close method.