### PR TITLE
Add badge linking to the latest Zenodo DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/78862024.svg)](https://zenodo.org/badge/latestdoi/78862024)
+
 # OME Files Benchmark
 
 The current repository contains the set of benchmark scripts used to test the


### PR DESCRIPTION
Following a recent discusion, the ome-files-performance repository was registered on http://zenodo.org/ via their GitHub integration.

A GitHub release was drafted using the existing `v0.1.0` tag and generated a first DOI for this source code and results. This PR adds a relative link to the latest DOI (i.e. it will update as new releases are drafted like other deployment badges).