### PR TITLE
Tiling performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,54 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>tiling</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+            <executions>
+              <execution>
+                <id>metadata</id>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+              </execution>
+            </executions>
+            <properties>
+              <tileXEnd>16</tileXEnd>
+              <tileYEnd>16</tileYEnd>
+              <test.tileOperator>"/"</test.tileOperator>
+              <test.tileIncrement>2</test.tileIncrement>
+              <test.series>0</test.series>
+              <test.autoTile>true</test.autoTile>
+            </properties>
+            <configuration>
+              <mainClass>ome.files.performance.TilingPerformance</mainClass>
+              <arguments>
+                <argument>${test.iterations}</argument>
+                <argument>${test.tileXStart}</argument>
+                <argument>${test.tileYStart}</argument>
+                <argument>${test.tileXEnd}</argument>
+                <argument>${test.tileYEnd}</argument>
+                <argument>${test.tileOperator}</argument>
+                <argument>${test.tileIncrement}</argument>
+                <argument>${test.series}</argument>
+                <argument>${test.autoTile}</argument>
+                <argument>${test.input}</argument>
+                <argument>${test.output}</argument>
+                <argument>${test.results}</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
     <test.input>test.file</test.input>
     <test.output>test.write</test.output>
     <test.results>test.results</test.results>
+    <test.tileXEnd>16</test.tileXEnd>
+    <test.tileYEnd>16</test.tileYEnd>
+    <test.tileOperator>"/"</test.tileOperator>
+    <test.tileIncrement>2</test.tileIncrement>
+    <test.series>0</test.series>
+    <test.autoTile>true</test.autoTile>
   </properties>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -259,14 +259,6 @@
                 </goals>
               </execution>
             </executions>
-            <properties>
-              <tileXEnd>16</tileXEnd>
-              <tileYEnd>16</tileYEnd>
-              <test.tileOperator>"/"</test.tileOperator>
-              <test.tileIncrement>2</test.tileIncrement>
-              <test.series>0</test.series>
-              <test.autoTile>true</test.autoTile>
-            </properties>
             <configuration>
               <mainClass>ome.files.performance.TilingPerformance</mainClass>
               <arguments>

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -132,3 +132,48 @@ for %%T in (bbbc mitocheck tubhiswt) do (
         install\bin\pixels-performance 1 !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp-%%I.tsv
     )
 )
+
+REM Run Java tiling performance tests
+for %%T in (neff-histopathology tubhiswt) do (
+    set test=%%T
+    set input=unknown
+
+    cd %WORKSPACE%\source
+
+    if [!test!] == [neff-histopathology] (
+        set input=%DATA_DIR%\ndpi\neff-histopathology\Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
+
+        REM Run Java tiling performance tests - very large image
+        REM call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        REM for /L %%I IN (1,1,!iterations!) do (
+            REM call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        REM )
+
+        REM Run Java tiling performance tests - large image
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+
+        REM Run Java tiling performance tests - medium image
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+    )
+    if [!test!] == [tubhiswt] (
+        set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
+
+        REM Run Java tiling performance tests - auto tiling
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+
+        REM Run Java tiling performance tests - manual tiling
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+    )
+)

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -54,3 +54,41 @@ for test in bbbc mitocheck tubhiswt; do
         done
     )
 done
+
+# Tiling Performance Tests
+for test in neff-histopathology tubhiswt; do
+    input=unknown
+    case "$test" in
+        neff-histopathology )
+            input=${datapath}/ndpi/neff-histopathology/Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
+            # Very Large
+            #mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            #for i in $(seq ${iterations}); do
+                #mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+            #done
+            # Large - Even divisions
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            for i in $(seq ${iterations}); do
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+            done
+            # Medium - Steady Increment
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            for i in $(seq ${iterations}); do
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+            done
+        ;;
+        tubhiswt)
+            input=${datapath}/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif
+            # Auto Tiling
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512  -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            for i in $(seq ${iterations}); do
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+            done
+            # Manual Tiling
+             mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            for i in $(seq ${iterations}); do
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+            done
+        ;;
+    esac
+done

--- a/src/main/java/ome/files/performance/Result.java
+++ b/src/main/java/ome/files/performance/Result.java
@@ -36,15 +36,22 @@ import java.io.Writer;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 class Result {
   private Writer writer;
   private PrintWriter output;
+  ResultMap<String,Object> customParams = new ResultMap<String,Object>();
 
   Result(Path filename) throws java.io.IOException {
     writer = new FileWriter(filename.toString());
     output = new PrintWriter(writer);
-    output.println("test.lang\ttest.name\ttest.file\treal\tproc.cpu\tproc.user\tproc.system");
+    output.println("test.lang\ttest.name\ttest.file\t"+customParams.keyToString()+"treal\tproc.cpu\tproc.user\tproc.system");
+  }
+  
+  void addCustomParam(String heading, Object value) {
+    customParams.put(heading, value);
   }
 
   void add(String testname,
@@ -53,14 +60,46 @@ class Result {
            Timepoint end) {
     output.println("Java\t" + testname + "\t" +
                    testfile.getFileName().toString() + "\t" +
+                   customParams.valueToString() +
                    (end.real-start.real)/1000000 + "\t" +
                    (end.cpu-start.cpu)/1000000 + "\t" +
                    (end.user-start.user)/1000000 + "\t" +
                    (end.system-start.system)/1000000);
 
   }
+  
+  void add(String testname, Path testfile, double size) {
+output.println("Java\t" + testname + "\t" +
+              testfile.getFileName().toString() + "\t" +
+              customParams.valueToString() +
+              0 + "\t" +
+              0 + "\t" +
+              0 + "\t" +
+              0 + "\t" + size);
+}
 
   void close() {
     output.close();
+  }
+  
+  private class ResultMap<K,V> extends HashMap<K,V> {
+
+    public String keyToString() {
+        String keyString = "";
+        for (Map.Entry<K, V> entry : this.entrySet()) {
+            keyString += entry.getKey();
+            keyString += "\t";
+        }
+        return keyString;
+    }
+    
+    public String valueToString() {
+      String valueString = "";
+      for (Map.Entry<K, V> entry : this.entrySet()) {
+          valueString += entry.getKey();
+          valueString += "\t";
+      }
+      return valueString;
+    }
   }
 }

--- a/src/main/java/ome/files/performance/TilingPerformance.java
+++ b/src/main/java/ome/files/performance/TilingPerformance.java
@@ -32,6 +32,7 @@
 
 package ome.files.performance;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,14 +44,16 @@ import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.ome.OMEXMLMetadataImpl;
 import loci.formats.out.OMETiffWriter;
 import loci.formats.out.TiffWriter;
+import loci.formats.tiff.IFD;
+import ome.xml.model.primitives.PositiveInteger;
 import loci.formats.FormatWriter;
 import loci.formats.ImageReader;
 
 public final class TilingPerformance {
 
   public static void main(String[] args) {
-    if (args.length != 6) {
-      System.out.println("Usage: TilingPerformance iterations tileSize autoTile inputfile outputfile resultfile\n");
+    if (args.length != 12) {
+      System.out.println("Usage: TilingPerformance iterations tileSizeXStart tileSizeYStart tileSizeXEnd tileSizeYEnd tileSizeOperator tileSizeIncrement series autoTile inputfile outputfile resultfile\n");
       System.exit(1);
     }
 
@@ -58,203 +61,263 @@ public final class TilingPerformance {
 
     try {
       int iterations = Integer.parseInt(args[0]);
-      int tileSize = Integer.parseInt(args[1]);
-      boolean autoTiling = Boolean.parseBoolean(args[2]);
-      Path infile = Paths.get(args[3]);
-      Path outfile = Paths.get(args[4]);
-      Path resultfile = Paths.get(args[5]);
+      int tileSizeXStart = Integer.parseInt(args[1]);
+      int tileSizeYStart = Integer.parseInt(args[2]);
+      int tileSizeXEnd = Integer.parseInt(args[3]);
+      int tileSizeYEnd = Integer.parseInt(args[4]);
+      String tileSizeOperator = args[5];
+      int tileSizeIncrement = Integer.parseInt(args[6]);
+      int series = Integer.parseInt(args[7]);
+      boolean autoTiling = Boolean.parseBoolean(args[8]);
+      Path infile = Paths.get(args[9]);
+      String outfileBase = args[10];
+      Path resultfile = Paths.get(args[11]);
 
+      
       result = new Result(resultfile);
 
       for(int i = 0; i < iterations; i++) {
-        System.out.print("pass " + i + ": init...");
-        System.out.flush();
-        OMEXMLMetadata meta = new OMEXMLMetadataImpl();
-        List<List<byte[]>> pixels = new ArrayList<List<byte[]>>();
-        ImageReader reader = new ImageReader();
-        reader.setMetadataStore(meta);
-        reader.setId(infile.toString());
-        int width = reader.getSizeX();
-        int height = reader.getSizeY();
-        
-        FormatWriter writer = new OMETiffWriter();
-        writer.setMetadataRetrieve(meta);
-        writer.setWriteSequentially(true);
-        writer.setInterleaved(true);
-        ((OMETiffWriter)writer).setBigTiff(true);
-        int tileSizeX = width;
-        int tileSizeY = height;
-        if (tileSize > 0) {
-          tileSizeX = writer.setTileSizeX(tileSize);
-          tileSizeY = writer.setTileSizeY(tileSize);         
-        }
-        int nXTiles = width / tileSizeX;
-        int nYTiles = height / tileSizeY;
-        if (nXTiles * tileSizeX != width) nXTiles++;
-        if (nYTiles * tileSizeY != height) nYTiles++;
-        int tilesPerImage = nXTiles * nYTiles;
-        
-        System.out.println("done");
-        System.out.flush();
-
-        {
-          for (int series = 0; series < reader.getSeriesCount(); ++series) {
-            System.out.print("pass " + i + ": convert series " + series + ": ");
+        int tileSizeX = tileSizeXStart;
+        int tileSizeY = tileSizeYStart;
+        while (tileSizeX >= tileSizeXEnd) {
+          tileSizeY = tileSizeYStart;
+          while (tileSizeY >= tileSizeYEnd) {
+            System.out.println("New tileX " + tileSizeX + " " + tileSizeY + " " + autoTiling);
+            result.addCustomParam("test.tileSizeX", tileSizeX);
+            result.addCustomParam("test.tileSizeY", tileSizeY);
+            Path outfile = Paths.get(outfileBase+"-"+tileSizeX+"-"+tileSizeY+".ome.tiff");
+            System.out.print("pass " + i + ": init...");
             System.out.flush();
+            OMEXMLMetadata meta = new OMEXMLMetadataImpl();
+            List<List<byte[]>> pixels = new ArrayList<List<byte[]>>();
+            ImageReader reader = new ImageReader();
+            reader.setMetadataStore(meta);
+            reader.setId(infile.toString());
             reader.setSeries(series);
-
-            List<byte[]> planes = new ArrayList<byte[]>();
-            pixels.add(planes);
-
-            for (int plane = 0; plane < reader.getImageCount(); ++plane) {
-              if (autoTiling) {
-                byte[] data = reader.openBytes(plane);
-                planes.add(data);
-              }
-              else {
-                for (int y=0; y<nYTiles; y++) {
-                  for (int x=0; x<nXTiles; x++) {
-                    int tileX = x * tileSizeX;
-                    int tileY = y * tileSizeY;
-                    int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
-                    int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
-
-                    byte[] data = reader.openBytes(plane, tileX, tileY, effTileSizeX, effTileSizeY);
-                    planes.add(data);
-                  }
-                }
-              }
-              System.out.print(".");
-              System.out.flush();
+            int width = reader.getSizeX();
+            int height = reader.getSizeY();
+            
+            FormatWriter writer = new OMETiffWriter();
+            OMEXMLMetadata writerMeta = new OMEXMLMetadataImpl();
+            writerMeta.setImageID("Image:0", 0);
+            writerMeta.setPixelsID("Pixels:0", 0);
+            writerMeta.setPixelsSizeX(new PositiveInteger(width), 0);
+            writerMeta.setPixelsSizeY(new PositiveInteger(height), 0);
+            writerMeta.setPixelsSizeZ(meta.getPixelsSizeZ(series), 0);
+            writerMeta.setPixelsSizeC(meta.getPixelsSizeC(series), 0);
+            writerMeta.setPixelsSizeT(meta.getPixelsSizeT(series), 0);
+            writerMeta.setPixelsBigEndian(meta.getPixelsBigEndian(series), 0);
+            writerMeta.setPixelsDimensionOrder(meta.getPixelsDimensionOrder(series), 0);
+            for (int channel=0; channel<meta.getChannelCount(series); channel++) {
+              writerMeta.setChannelID("Channel:0:" + channel, 0, channel);
+              writerMeta.setChannelSamplesPerPixel(meta.getChannelSamplesPerPixel(series, channel), 0, channel);
             }
+            writerMeta.setPixelsType(meta.getPixelsType(series), 0);
+            writer.setMetadataRetrieve(writerMeta);
+            writer.setWriteSequentially(true);
+            writer.setInterleaved(true);
+            ((OMETiffWriter)writer).setBigTiff(true);
+            if (tileSizeX > 0) {
+              tileSizeX = writer.setTileSizeX(tileSizeX);       
+            }
+            else {
+              tileSizeX = width;
+            }
+            if (tileSizeY > 0) {
+              tileSizeY = writer.setTileSizeY(tileSizeY);         
+            }
+            else {
+              tileSizeY = height;
+            }
+            int nXTiles = width / tileSizeX;
+            int nYTiles = height / tileSizeY;
+            if (nXTiles * tileSizeX != width) nXTiles++;
+            if (nYTiles * tileSizeY != height) nYTiles++;
+            int tilesPerImage = nXTiles * nYTiles;
+            
             System.out.println("done");
             System.out.flush();
-          }
-          reader.close();
-        }
-
-        Files.deleteIfExists(outfile);
-
-        Timepoint write_start = new Timepoint();
-        Timepoint write_init = null;
-        Timepoint close_start = null;
-
-        {
-          System.out.print("pass " + i + ": write init...");
-          System.out.flush();
-
-          writer.setId(outfile.toString());
-
-          System.out.println("done");
-          System.out.flush();
-
-          write_init = new Timepoint();
-
-          for (int series = 0; series < pixels.size(); ++series) {
-            System.out.print("pass " + i + ": write series " + series + ": ");
-            System.out.flush();
-            writer.setInterleaved(true);
-            writer.setSeries(series);
-
-            List<byte[]> planes = pixels.get(series);
-            int dataIndex = 0;
-            int imageCount = planes.size();
-            if (!autoTiling) {
-              imageCount = imageCount / tilesPerImage;
-            }
-
-            for (int plane = 0; plane < imageCount; ++plane) {
-              if (autoTiling) {
-                byte[] data = planes.get(dataIndex);
-                ((TiffWriter) writer).saveBytes(plane, data);
-                dataIndex++;
+    
+            {
+              System.out.print("pass " + i + ": convert series " + series + ": ");
+              System.out.flush();
+              reader.setSeries(series);
+  
+              List<byte[]> planes = new ArrayList<byte[]>();
+              pixels.add(planes);
+  
+              for (int plane = 0; plane < reader.getImageCount(); ++plane) {
+                if (autoTiling) {
+                  byte[] data = reader.openBytes(plane);
+                  planes.add(data);
+                }
+                else {
+                  for (int y=0; y<nYTiles; y++) {
+                    for (int x=0; x<nXTiles; x++) {
+                      int tileX = x * tileSizeX;
+                      int tileY = y * tileSizeY;
+                      int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+                      int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+  
+                      byte[] data = reader.openBytes(plane, tileX, tileY, effTileSizeX, effTileSizeY);
+                      planes.add(data);
+                    }
+                  }
+                }
+                System.out.print(".");
+                System.out.flush();
               }
-              else {
-                for (int y=0; y<nYTiles; y++) {
-                  for (int x=0; x<nXTiles; x++) {
-                    int tileX = x * tileSizeX;
-                    int tileY = y * tileSizeY;
-                    int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
-                    int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
-                    byte[] data = planes.get(dataIndex);
+              System.out.println("done");
+              System.out.flush();
 
-                    writer.saveBytes(plane, data, tileX, tileY, effTileSizeX, effTileSizeY);
+              reader.close();
+            }
+    
+            Files.deleteIfExists(outfile);
+    
+            Timepoint write_start = new Timepoint();
+            Timepoint write_init = null;
+            Timepoint close_start = null;
+    
+            {
+              System.out.print("pass " + i + ": write init...");
+              System.out.flush();
+    
+              writer.setId(outfile.toString());
+    
+              System.out.println("done");
+              System.out.flush();
+    
+              write_init = new Timepoint();
+    
+              for (int seriesNum = 0; seriesNum < pixels.size(); ++seriesNum) {
+                System.out.print("pass " + i + ": write series " + seriesNum + ": ");
+                System.out.flush();
+                writer.setInterleaved(true);
+                writer.setSeries(seriesNum);
+    
+                List<byte[]> planes = pixels.get(seriesNum);
+                int dataIndex = 0;
+                int imageCount = planes.size();
+                if (!autoTiling) {
+                  imageCount = imageCount / tilesPerImage;
+                }
+    
+                for (int plane = 0; plane < imageCount; ++plane) {
+                  if (autoTiling) {
+                    byte[] data = planes.get(dataIndex);
+                    ((TiffWriter) writer).saveBytes(plane, data);
                     dataIndex++;
                   }
+                  else {
+                    IFD ifd = new IFD();
+                    ifd.put(new Integer(IFD.TILE_WIDTH), new Long(tileSizeX));
+                    ifd.put(new Integer(IFD.TILE_LENGTH), new Long(tileSizeY));
+                    for (int y=0; y<nYTiles; y++) {
+                      for (int x=0; x<nXTiles; x++) {
+                        int tileX = x * tileSizeX;
+                        int tileY = y * tileSizeY;
+                        int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+                        int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+                        byte[] data = planes.get(dataIndex);
+    
+                        ((TiffWriter) writer).saveBytes(plane, data, ifd, tileX, tileY, effTileSizeX, effTileSizeY);
+                        dataIndex++;
+                      }
+                    }
+                  }
+                  System.out.print(".");
+                  System.out.flush();
                 }
+                System.out.println("done");
+                System.out.flush();
               }
-              System.out.print(".");
-              System.out.flush();
+              close_start = new Timepoint();
+              writer.close();
             }
-            System.out.println("done");
-            System.out.flush();
-          }
-          close_start = new Timepoint();
-          writer.close();
-        }
-
-        Timepoint write_end = new Timepoint();
-
-        result.add("tiling.write", infile, write_start, write_end);
-        result.add("tiling.write.init", infile, write_start, write_init);
-        result.add("tiling.write.pixels", infile, write_init, close_start);
-        result.add("tiling.write.close", infile, close_start, write_end);
-        
-        {
-          Timepoint read_start = new Timepoint();
-          Timepoint read_init = null;
-
-          System.out.print("pass " + i + ": read init...");
-          System.out.flush();
-          
-          reader = new ImageReader();
-          reader.setMetadataStore(meta);
-          reader.setId(outfile.toString());
-
-          System.out.println("done");
-          System.out.flush();
-
-          read_init = new Timepoint();
-
-          for (int series = 0; series < reader.getSeriesCount(); ++series) {
-            System.out.print("pass " + i + ": read series " + series + ": ");
-            System.out.flush();
-            reader.setSeries(series);
-
-            List<byte[]> planes = new ArrayList<byte[]>();
-            pixels.add(planes);
-
-            for (int plane = 0; plane < reader.getImageCount(); ++plane) {
-              if (autoTiling) {
-                byte[] data = reader.openBytes(plane);
-                planes.add(data);
-              }
-              else {
-                for (int y=0; y<nYTiles; y++) {
-                  for (int x=0; x<nXTiles; x++) {
-                    int tileX = x * tileSizeX;
-                    int tileY = y * tileSizeY;
-                    int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
-                    int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
-
-                    byte[] data = reader.openBytes(plane, tileX, tileY, effTileSizeX, effTileSizeY);
+    
+            Timepoint write_end = new Timepoint();
+    
+            result.add("tiling.write", infile, write_start, write_end);
+            result.add("tiling.write.init", infile, write_start, write_init);
+            result.add("tiling.write.pixels", infile, write_init, close_start);
+            result.add("tiling.write.close", infile, close_start, write_end);
+            
+            File file =new File(outfile.toString());
+            double bytes = file.length();
+            double kilobytes = (bytes / 1024);
+            double megabytes = (kilobytes / 1024);
+            result.add("tiling.write.filesize", infile, megabytes);
+            
+            {
+              Timepoint read_start = new Timepoint();
+              Timepoint read_init = null;
+    
+              System.out.print("pass " + i + ": read init...");
+              System.out.flush();
+              
+              reader = new ImageReader();
+              reader.setMetadataStore(meta);
+              reader.setId(outfile.toString());
+    
+              System.out.println("done");
+              System.out.flush();
+    
+              read_init = new Timepoint();
+    
+              for (int seriesNum = 0; seriesNum < reader.getSeriesCount(); ++seriesNum) {
+                System.out.print("pass " + i + ": read series " + seriesNum + ": ");
+                System.out.flush();
+                reader.setSeries(seriesNum);
+    
+                List<byte[]> planes = new ArrayList<byte[]>();
+                pixels.add(planes);
+    
+                for (int plane = 0; plane < reader.getImageCount(); ++plane) {
+                  if (autoTiling) {
+                    byte[] data = reader.openBytes(plane);
                     planes.add(data);
                   }
+                  else {
+                    for (int y=0; y<nYTiles; y++) {
+                      for (int x=0; x<nXTiles; x++) {
+                        int tileX = x * tileSizeX;
+                        int tileY = y * tileSizeY;
+                        int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+                        int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+    
+                        byte[] data = reader.openBytes(plane, tileX, tileY, effTileSizeX, effTileSizeY);
+                        planes.add(data);
+                      }
+                    }
+                  }
+                  System.out.print(".");
+                  System.out.flush();
                 }
+                System.out.println("done");
+                System.out.flush();
               }
-              System.out.print(".");
-              System.out.flush();
+              reader.close();
+              file.delete();
+              Timepoint read_end = new Timepoint();
+    
+              result.add("tiling.read", infile, read_start, read_end);
+              result.add("tiling.read.ini", infile, read_start, read_init);
+              result.add("tiling.read.pixels", infile, read_init, read_end);
             }
-            System.out.println("done");
-            System.out.flush();
+            if (tileSizeOperator.equals("-")) {
+              tileSizeY = tileSizeY - tileSizeIncrement;
+            }
+            else {
+              tileSizeY = tileSizeY / tileSizeIncrement;
+            }
           }
-          reader.close();
-          
-          Timepoint read_end = new Timepoint();
-
-          result.add("tiling.read", infile, read_start, read_end);
-          result.add("tiling.read.ini", infile, read_start, read_init);
-          result.add("tiling.read.pixels", infile, read_init, read_end);
+          if (tileSizeOperator.equals("-")) {
+            tileSizeX = tileSizeX - tileSizeIncrement;
+          }
+          else {
+            tileSizeX = tileSizeX / tileSizeIncrement;
+          }
         }
       }
 

--- a/src/main/java/ome/files/performance/TilingPerformance.java
+++ b/src/main/java/ome/files/performance/TilingPerformance.java
@@ -1,0 +1,273 @@
+/*
+ * #%L
+ * Common package for I/O and related utilities
+ * %%
+ * Copyright (C) 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package ome.files.performance;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.ome.OMEXMLMetadataImpl;
+import loci.formats.out.OMETiffWriter;
+import loci.formats.out.TiffWriter;
+import loci.formats.FormatWriter;
+import loci.formats.ImageReader;
+
+public final class TilingPerformance {
+
+  public static void main(String[] args) {
+    if (args.length != 6) {
+      System.out.println("Usage: TilingPerformance iterations tileSize autoTile inputfile outputfile resultfile\n");
+      System.exit(1);
+    }
+
+    Result result = null;
+
+    try {
+      int iterations = Integer.parseInt(args[0]);
+      int tileSize = Integer.parseInt(args[1]);
+      boolean autoTiling = Boolean.parseBoolean(args[2]);
+      Path infile = Paths.get(args[3]);
+      Path outfile = Paths.get(args[4]);
+      Path resultfile = Paths.get(args[5]);
+
+      result = new Result(resultfile);
+
+      for(int i = 0; i < iterations; i++) {
+        System.out.print("pass " + i + ": init...");
+        System.out.flush();
+        OMEXMLMetadata meta = new OMEXMLMetadataImpl();
+        List<List<byte[]>> pixels = new ArrayList<List<byte[]>>();
+        ImageReader reader = new ImageReader();
+        reader.setMetadataStore(meta);
+        reader.setId(infile.toString());
+        int width = reader.getSizeX();
+        int height = reader.getSizeY();
+        
+        FormatWriter writer = new OMETiffWriter();
+        writer.setMetadataRetrieve(meta);
+        writer.setWriteSequentially(true);
+        writer.setInterleaved(true);
+        ((OMETiffWriter)writer).setBigTiff(true);
+        int tileSizeX = width;
+        int tileSizeY = height;
+        if (tileSize > 0) {
+          tileSizeX = writer.setTileSizeX(tileSize);
+          tileSizeY = writer.setTileSizeY(tileSize);         
+        }
+        int nXTiles = width / tileSizeX;
+        int nYTiles = height / tileSizeY;
+        if (nXTiles * tileSizeX != width) nXTiles++;
+        if (nYTiles * tileSizeY != height) nYTiles++;
+        int tilesPerImage = nXTiles * nYTiles;
+        
+        System.out.println("done");
+        System.out.flush();
+
+        {
+          for (int series = 0; series < reader.getSeriesCount(); ++series) {
+            System.out.print("pass " + i + ": convert series " + series + ": ");
+            System.out.flush();
+            reader.setSeries(series);
+
+            List<byte[]> planes = new ArrayList<byte[]>();
+            pixels.add(planes);
+
+            for (int plane = 0; plane < reader.getImageCount(); ++plane) {
+              if (autoTiling) {
+                byte[] data = reader.openBytes(plane);
+                planes.add(data);
+              }
+              else {
+                for (int y=0; y<nYTiles; y++) {
+                  for (int x=0; x<nXTiles; x++) {
+                    int tileX = x * tileSizeX;
+                    int tileY = y * tileSizeY;
+                    int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+                    int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+
+                    byte[] data = reader.openBytes(plane, tileX, tileY, effTileSizeX, effTileSizeY);
+                    planes.add(data);
+                  }
+                }
+              }
+              System.out.print(".");
+              System.out.flush();
+            }
+            System.out.println("done");
+            System.out.flush();
+          }
+          reader.close();
+        }
+
+        Files.deleteIfExists(outfile);
+
+        Timepoint write_start = new Timepoint();
+        Timepoint write_init = null;
+        Timepoint close_start = null;
+
+        {
+          System.out.print("pass " + i + ": write init...");
+          System.out.flush();
+
+          writer.setId(outfile.toString());
+
+          System.out.println("done");
+          System.out.flush();
+
+          write_init = new Timepoint();
+
+          for (int series = 0; series < pixels.size(); ++series) {
+            System.out.print("pass " + i + ": write series " + series + ": ");
+            System.out.flush();
+            writer.setInterleaved(true);
+            writer.setSeries(series);
+
+            List<byte[]> planes = pixels.get(series);
+            int dataIndex = 0;
+            int imageCount = planes.size();
+            if (!autoTiling) {
+              imageCount = imageCount / tilesPerImage;
+            }
+
+            for (int plane = 0; plane < imageCount; ++plane) {
+              if (autoTiling) {
+                byte[] data = planes.get(dataIndex);
+                ((TiffWriter) writer).saveBytes(plane, data);
+                dataIndex++;
+              }
+              else {
+                for (int y=0; y<nYTiles; y++) {
+                  for (int x=0; x<nXTiles; x++) {
+                    int tileX = x * tileSizeX;
+                    int tileY = y * tileSizeY;
+                    int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+                    int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+                    byte[] data = planes.get(dataIndex);
+
+                    writer.saveBytes(plane, data, tileX, tileY, effTileSizeX, effTileSizeY);
+                    dataIndex++;
+                  }
+                }
+              }
+              System.out.print(".");
+              System.out.flush();
+            }
+            System.out.println("done");
+            System.out.flush();
+          }
+          close_start = new Timepoint();
+          writer.close();
+        }
+
+        Timepoint write_end = new Timepoint();
+
+        result.add("tiling.write", infile, write_start, write_end);
+        result.add("tiling.write.init", infile, write_start, write_init);
+        result.add("tiling.write.pixels", infile, write_init, close_start);
+        result.add("tiling.write.close", infile, close_start, write_end);
+        
+        {
+          Timepoint read_start = new Timepoint();
+          Timepoint read_init = null;
+
+          System.out.print("pass " + i + ": read init...");
+          System.out.flush();
+          
+          reader = new ImageReader();
+          reader.setMetadataStore(meta);
+          reader.setId(outfile.toString());
+
+          System.out.println("done");
+          System.out.flush();
+
+          read_init = new Timepoint();
+
+          for (int series = 0; series < reader.getSeriesCount(); ++series) {
+            System.out.print("pass " + i + ": read series " + series + ": ");
+            System.out.flush();
+            reader.setSeries(series);
+
+            List<byte[]> planes = new ArrayList<byte[]>();
+            pixels.add(planes);
+
+            for (int plane = 0; plane < reader.getImageCount(); ++plane) {
+              if (autoTiling) {
+                byte[] data = reader.openBytes(plane);
+                planes.add(data);
+              }
+              else {
+                for (int y=0; y<nYTiles; y++) {
+                  for (int x=0; x<nXTiles; x++) {
+                    int tileX = x * tileSizeX;
+                    int tileY = y * tileSizeY;
+                    int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+                    int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+
+                    byte[] data = reader.openBytes(plane, tileX, tileY, effTileSizeX, effTileSizeY);
+                    planes.add(data);
+                  }
+                }
+              }
+              System.out.print(".");
+              System.out.flush();
+            }
+            System.out.println("done");
+            System.out.flush();
+          }
+          reader.close();
+          
+          Timepoint read_end = new Timepoint();
+
+          result.add("tiling.read", infile, read_start, read_end);
+          result.add("tiling.read.ini", infile, read_start, read_init);
+          result.add("tiling.read.pixels", infile, read_init, read_end);
+        }
+      }
+
+      result.close();
+      System.exit(0);
+    }
+    catch(Exception e) {
+      if (result != null) {
+        result.close();
+      }
+      System.err.println("Error: caught exception: " + e);
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+}


### PR DESCRIPTION
Whats included in this PR:

- Java code for tiling tests
- Maven pom updates
- Benchmark scripts updates
- Jenkins scripts updates

What isn't included:
- analysis scripts

Tests:
Large Image
Series 1 - Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
Starting with a tile size of 30720x25856, then dividing the tile x and y by 2 until tile size reaches 16x16.

Medium Image 
Series 2 - Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
Starting with a tile size of 7680x6464, then subtracting 64 from the tile x and y until tile size reaches 16x16.

Manual Tiling
tubhiswt_C0_TP0.ome.tif
Starting with a tile of size 512x512, then dividing the tile x and y by 2 until tile size reaches 16x16. Writes each tile individually.

Auto Tiling
tubhiswt_C0_TP0.ome.tif
Starting with a tile of size 512x512, then dividing the tile x and y by 2 until tile size reaches 16x16. Writes a full plane with the auto tiling.

Available parameters:
iterations
input
output
results
tileXStart
tileYStart
tileXEnd
tileYEnd
tileOperator (either / or -)
tileIncrement (how much to divide or subtract tile size by)
series
autoTile