### PR TITLE
Refactor benchmarking scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
       <artifactId>formats-bsd</artifactId>
       <version>5.3.4</version>
     </dependency>
+    <dependency>
+      <groupId>ome</groupId>
+      <artifactId>formats-gpl</artifactId>
+      <version>5.3.4</version>
+    </dependency>
   </dependencies>
   <properties>
     <!-- NB: Avoid platform encoding warning when copying resources. -->

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -91,17 +91,20 @@ set outdir=%WORKSPACE%\out
 set resultsdir=%WORKSPACE%\results
 
 set do_default=true
-if exist "metadata" (
-    call metadata.bat
-    set do_default=false
-)
-if exist "pixeldata" (
-    call pixeldata.bat
-    set do_default=false
-)
-if exist "tiling" (
-    call tiling.bat
-    set do_default=false
+REM Read the options
+for %%I in (%*) do (
+    if %%I == metadata (
+        call metadata.bat
+        set do_default=false
+    )
+    if %%I = pixeldata (
+        call pixeldata.bat
+        set do_default=false
+    )
+    if %%I == tiling (
+        call tiling.bat
+        set do_default=false
+    )
 )
 if [%do_default%] == [true] (
     call metadata.bat

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -90,90 +90,21 @@ set iterations=1
 set outdir=%WORKSPACE%\out
 set resultsdir=%WORKSPACE%\results
 
-for %%T in (bbbc mitocheck tubhiswt) do (
-    set test=%%T
-    set input=unknown
-    if [!test!] == [bbbc] (
-        set input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff
-    )
-    if [!test!] == [mitocheck] (
-        set input=%DATA_DIR%\mitocheck\00001_01.ome.tiff
-    )
-    if [!test!] == [tubhiswt] (
-        set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
-    )
-
-    cd %WORKSPACE%\source
-
-    REM Run Java metadata performance tests
-    call mvn -P metadata -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
-    for /L %%I IN (1,1,!iterations!) do (
-        call mvn -P metadata -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
-    )
-
-    REM Run Java pixels performance tests
-    call mvn -P pixels -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java.tsv exec:java
-    for /L %%I IN (1,1,!iterations!) do (
-        call mvn -P pixels -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
-    )
-
-    REM Execute C++ performance tests
-    cd "%WORKSPACE%"
-
-    REM Run C++ metadata tests
-    install\bin\metadata-performance %iterations% !input!  %outdir%\!test!-cpp.ome.xml %resultsdir%\!test!-metadata-win-cpp.tsv
-    for /L %%I IN (1,1,!iterations!) do (
-        install\bin\metadata-performance 1 !input!  %outdir%\!test!-cpp.ome.xml %resultsdir%\!test!-metadata-win-cpp-%%I.tsv
-    )
-
-    REM Run C++ pixels performance tests
-    install\bin\pixels-performance %iterations% !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp.tsv
-    for /L %%I IN (1,1,!iterations!) do (
-        install\bin\pixels-performance 1 !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp-%%I.tsv
-    )
+set do_default=true
+if exist "metadata" (
+    call metadata.bat
+    set do_default=false
 )
-
-REM Run Java tiling performance tests
-for %%T in (neff-histopathology tubhiswt) do (
-    set test=%%T
-    set input=unknown
-
-    cd %WORKSPACE%\source
-
-    if [!test!] == [neff-histopathology] (
-        set input=%DATA_DIR%\ndpi\neff-histopathology\Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
-
-        REM Run Java tiling performance tests - very large image
-        REM call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
-        REM for /L %%I IN (1,1,!iterations!) do (
-            REM call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
-        REM )
-
-        REM Run Java tiling performance tests - large image
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
-        for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
-        )
-
-        REM Run Java tiling performance tests - medium image
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
-        for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
-        )
-    )
-    if [!test!] == [tubhiswt] (
-        set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
-
-        REM Run Java tiling performance tests - auto tiling
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
-        for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
-        )
-
-        REM Run Java tiling performance tests - manual tiling
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
-        for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
-        )
-    )
+if exist "pixeldata" (
+    call pixeldata.bat
+    set do_default=false
+)
+if exist "tiling" (
+    call tiling.bat
+    set do_default=false
+)
+if [%do_default%] == [true] (
+    call metadata.bat
+    call pixeldata.bat
+    call tiling.bat
 )

--- a/scripts/metadata.bat
+++ b/scripts/metadata.bat
@@ -1,0 +1,39 @@
+@echo off
+REM Build with Jenkins CI.  This script is intended for use with the OME
+REM Jenkins CI infrastructure, though it may be useful as an example for
+REM how one might use various cmake options.
+
+REM So that statements like "set" work inside nested conditionals
+setlocal ENABLEDELAYEDEXPANSION
+setlocal ENABLEEXTENSIONS
+
+for %%T in (bbbc mitocheck tubhiswt) do (
+    set test=%%T
+    set input=unknown
+    if [!test!] == [bbbc] (
+        set input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff
+    )
+    if [!test!] == [mitocheck] (
+        set input=%DATA_DIR%\mitocheck\00001_01.ome.tiff
+    )
+    if [!test!] == [tubhiswt] (
+        set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
+    )
+
+    cd %WORKSPACE%\source
+
+    REM Run Java metadata performance tests
+    call mvn -P metadata -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+    for /L %%I IN (1,1,!iterations!) do (
+        call mvn -P metadata -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+    )
+
+    REM Execute C++ performance tests
+    cd "%WORKSPACE%"
+
+    REM Run C++ metadata tests
+    install\bin\metadata-performance %iterations% !input!  %outdir%\!test!-cpp.ome.xml %resultsdir%\!test!-metadata-win-cpp.tsv
+    for /L %%I IN (1,1,!iterations!) do (
+        install\bin\metadata-performance 1 !input!  %outdir%\!test!-cpp.ome.xml %resultsdir%\!test!-metadata-win-cpp-%%I.tsv
+    )
+)

--- a/scripts/pixeldata.bat
+++ b/scripts/pixeldata.bat
@@ -1,0 +1,39 @@
+@echo off
+REM Build with Jenkins CI.  This script is intended for use with the OME
+REM Jenkins CI infrastructure, though it may be useful as an example for
+REM how one might use various cmake options.
+
+REM So that statements like "set" work inside nested conditionals
+setlocal ENABLEDELAYEDEXPANSION
+setlocal ENABLEEXTENSIONS
+
+for %%T in (bbbc mitocheck tubhiswt) do (
+    set test=%%T
+    set input=unknown
+    if [!test!] == [bbbc] (
+        set input=%DATA_DIR%\BBBC\NIRHTa-001.ome.tiff
+    )
+    if [!test!] == [mitocheck] (
+        set input=%DATA_DIR%\mitocheck\00001_01.ome.tiff
+    )
+    if [!test!] == [tubhiswt] (
+        set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
+    )
+
+    cd %WORKSPACE%\source
+
+    REM Run Java pixels performance tests
+    call mvn -P pixels -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java.tsv exec:java
+    for /L %%I IN (1,1,!iterations!) do (
+        call mvn -P pixels -Dtest.iterations=1 -Dtest.input=!input! -Dtest.output=%outdir%\!test!-java.ome.tiff -Dtest.results=%resultsdir%\!test!-pixeldata-win-java-%%I.tsv exec:java
+    )
+
+    REM Execute C++ performance tests
+    cd "%WORKSPACE%"
+
+    REM Run C++ pixels performance tests
+    install\bin\pixels-performance %iterations% !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp.tsv
+    for /L %%I IN (1,1,!iterations!) do (
+        install\bin\pixels-performance 1 !input! %outdir%\!test!-cpp.ome.tiff %resultsdir%\!test!-pixeldata-win-cpp-%%I.tsv
+    )
+)

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -1,0 +1,38 @@
+#! /bin/sh
+set -e
+set -x
+
+export datapath="/data"
+export binpath="/install/bin"
+export resultpath="${datapath}/results"
+export outpath="${datapath}/out"
+export iterations=1
+
+# Clean results folder
+mkdir -p "${resultpath}"
+mkdir -p "${outpath}"
+rm "${resultpath}"/* || echo "No results"
+rm "${outpath}"/* || echo "No output"
+
+run_all_benchmarks=true
+# read the options
+for var in "$@"
+do
+    if [ "$var" == "metadata" ];  then
+        run_all_benchmarks=false
+        ./run_metadata
+    fi
+    if [ "$var" == "pixeldata" ];  then
+        run_all_benchmarks=false
+        ./run_pixeldata
+    fi
+    if [ "$var" == "tiling" ];  then
+        run_all_benchmarks=false
+        ./run_tiling
+    fi
+done
+if [ "$run_all_benchmarks" == "true" ];  then
+    ./run_metadata
+    ./run_pixeldata
+    ./run_tiling
+fi

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -15,24 +15,25 @@ rm "${resultpath}"/* || echo "No results"
 rm "${outpath}"/* || echo "No output"
 
 run_all_benchmarks=true
+dir="$(dirname "$0")"
 # read the options
 for var in "$@"
 do
     if [ "$var" == "metadata" ];  then
         run_all_benchmarks=false
-        ./run_metadata
+        $dir/run_metadata
     fi
     if [ "$var" == "pixeldata" ];  then
         run_all_benchmarks=false
-        ./run_pixeldata
+        $dir/run_pixeldata
     fi
     if [ "$var" == "tiling" ];  then
         run_all_benchmarks=false
-        ./run_tiling
+        $dir/run_tiling
     fi
 done
 if [ "$run_all_benchmarks" == "true" ];  then
-    ./run_metadata
-    ./run_pixeldata
-    ./run_tiling
+    $dir/run_metadata
+    $dir/run_pixeldata
+    $dir/run_tiling
 fi

--- a/scripts/run_benchmarking
+++ b/scripts/run_benchmarking
@@ -19,20 +19,20 @@ dir="$(dirname "$0")"
 # read the options
 for var in "$@"
 do
-    if [ "$var" == "metadata" ];  then
+    if [ "$var" = "metadata" ];  then
         run_all_benchmarks=false
         $dir/run_metadata
     fi
-    if [ "$var" == "pixeldata" ];  then
+    if [ "$var" = "pixeldata" ];  then
         run_all_benchmarks=false
         $dir/run_pixeldata
     fi
-    if [ "$var" == "tiling" ];  then
+    if [ "$var" = "tiling" ];  then
         run_all_benchmarks=false
         $dir/run_tiling
     fi
 done
-if [ "$run_all_benchmarks" == "true" ];  then
+if [ "$run_all_benchmarks" = "true" ];  then
     $dir/run_metadata
     $dir/run_pixeldata
     $dir/run_tiling

--- a/scripts/run_metadata
+++ b/scripts/run_metadata
@@ -1,0 +1,34 @@
+#! /bin/sh
+set -e
+set -x
+
+for test in bbbc mitocheck tubhiswt; do
+    input=unknown
+    case "$test" in
+        bbbc)
+            input=${datapath}/BBBC/NIRHTa-001.ome.tiff
+        ;;
+        mitocheck)
+            input=${datapath}/mitocheck/00001_01.ome.tiff
+        ;;
+        tubhiswt)
+            input=${datapath}/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif
+        ;;
+    esac
+
+    # Java tests
+    (
+        mvn -P metadata -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+        for i in $(seq ${iterations}); do
+            mvn -P metadata -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+        done
+    )
+
+    # C++ tests
+    (
+        ${binpath}/metadata-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.xml ${resultpath}/${test}-metadata-linux-cpp.tsv
+        for i in $(seq ${iterations}); do
+            ${binpath}/metadata-performance 1 "$input" ${outpath}/${test}-cpp.ome.xml ${resultpath}/${test}-metadata-linux-cpp-${i}.tsv
+        done
+    )
+done

--- a/scripts/run_pixeldata
+++ b/scripts/run_pixeldata
@@ -1,0 +1,34 @@
+#! /bin/sh
+set -e
+set -x
+
+for test in bbbc mitocheck tubhiswt; do
+    input=unknown
+    case "$test" in
+        bbbc)
+            input=${datapath}/BBBC/NIRHTa-001.ome.tiff
+        ;;
+        mitocheck)
+            input=${datapath}/mitocheck/00001_01.ome.tiff
+        ;;
+        tubhiswt)
+            input=${datapath}/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif
+        ;;
+    esac
+
+    # Java tests
+    (
+        mvn -P pixels -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java.tsv exec:java
+        for i in $(seq ${iterations}); do
+            mvn -P pixels -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
+        done
+    )
+
+    # C++ tests
+    (
+        ${binpath}/pixels-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp.tsv
+        for i in $(seq ${iterations}); do
+            ${binpath}/pixels-performance 1 "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp-${i}.tsv
+        done
+    )
+done

--- a/scripts/run_tiling
+++ b/scripts/run_tiling
@@ -2,59 +2,6 @@
 set -e
 set -x
 
-datapath="/data"
-binpath="/install/bin"
-resultpath="${datapath}/results"
-outpath="${datapath}/out"
-iterations=1
-
-# Clean results folder
-mkdir -p "${resultpath}"
-mkdir -p "${outpath}"
-rm "${resultpath}"/* || echo "No results"
-rm "${outpath}"/* || echo "No output"
-
-for test in bbbc mitocheck tubhiswt; do
-    input=unknown
-    case "$test" in
-        bbbc)
-            input=${datapath}/BBBC/NIRHTa-001.ome.tiff
-        ;;
-        mitocheck)
-            input=${datapath}/mitocheck/00001_01.ome.tiff
-        ;;
-        tubhiswt)
-            input=${datapath}/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif
-        ;;
-    esac
-
-    # Java tests
-    (
-        mvn -P metadata -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
-        for i in $(seq ${iterations}); do
-            mvn -P metadata -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
-        done
-
-        mvn -P pixels -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java.tsv exec:java
-        for i in $(seq ${iterations}); do
-            mvn -P pixels -Dtest.iterations=1 -Dtest.input="$input" -Dtest.output=${outpath}/${test}-java.ome.tiff -Dtest.results=${resultpath}/${test}-pixeldata-linux-java-${i}.tsv exec:java
-        done
-    )
-
-    # C++ tests
-    (
-        ${binpath}/metadata-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.xml ${resultpath}/${test}-metadata-linux-cpp.tsv
-        for i in $(seq ${iterations}); do
-            ${binpath}/metadata-performance 1 "$input" ${outpath}/${test}-cpp.ome.xml ${resultpath}/${test}-metadata-linux-cpp-${i}.tsv
-        done
-
-        ${binpath}/pixels-performance ${iterations} "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp.tsv
-        for i in $(seq ${iterations}); do
-            ${binpath}/pixels-performance 1 "$input" ${outpath}/${test}-cpp.ome.tiff ${resultpath}/${test}-pixeldata-linux-cpp-${i}.tsv
-        done
-    )
-done
-
 # Tiling Performance Tests
 for test in neff-histopathology tubhiswt; do
     input=unknown

--- a/scripts/run_tiling
+++ b/scripts/run_tiling
@@ -7,7 +7,7 @@ for test in neff-histopathology tubhiswt; do
     input=unknown
     case "$test" in
         neff-histopathology )
-            input=${datapath}/ndpi/neff-histopathology/Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
+            input="${datapath}/ndpi/neff-histopathology/Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi"
             # Very Large
             #mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
             #for i in $(seq ${iterations}); do

--- a/scripts/run_tiling
+++ b/scripts/run_tiling
@@ -14,9 +14,9 @@ for test in neff-histopathology tubhiswt; do
                 #mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-linux-java-${i}.tsv exec:java
             #done
             # Large - Even divisions
-            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-large-linux-java.tsv exec:java
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=15360 -Dtest.tileYStart=12928 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-large-linux-java.tsv exec:java
             for i in $(seq ${iterations}); do
-                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—large-linux-java-${i}.tsv exec:java
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=15360 -Dtest.tileYStart=12928 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—large-linux-java-${i}.tsv exec:java
             done
             # Medium - Steady Increment
             mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—medium-linux-java.tsv exec:java

--- a/scripts/run_tiling
+++ b/scripts/run_tiling
@@ -9,32 +9,32 @@ for test in neff-histopathology tubhiswt; do
         neff-histopathology )
             input="${datapath}/ndpi/neff-histopathology/Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi"
             # Very Large
-            #mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            #mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-linux-java.tsv exec:java
             #for i in $(seq ${iterations}); do
-                #mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+                #mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-linux-java-${i}.tsv exec:java
             #done
             # Large - Even divisions
-            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-large-linux-java.tsv exec:java
             for i in $(seq ${iterations}); do
-                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—large-linux-java-${i}.tsv exec:java
             done
             # Medium - Steady Increment
-            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—medium-linux-java.tsv exec:java
             for i in $(seq ${iterations}); do
-                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-medium-linux-java-${i}.tsv exec:java
             done
         ;;
         tubhiswt)
             input=${datapath}/tubhiswt-4D/tubhiswt_C0_TP0.ome.tif
             # Auto Tiling
-            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512  -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+            mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512  -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-autotile-linux-java.tsv exec:java
             for i in $(seq ${iterations}); do
-                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling-autotile-linux-java-${i}.tsv exec:java
             done
             # Manual Tiling
-             mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java.tsv exec:java
+             mvn -P tiling -Dtest.iterations=${iterations} -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—noauto-linux-java.tsv exec:java
             for i in $(seq ${iterations}); do
-                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-metadata-linux-java-${i}.tsv exec:java
+                mvn -P tiling -Dtest.iterations=1 -Dtest.input="$input" -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=${outpath}/${test}-java.ome.xml -Dtest.results=${resultpath}/${test}-tiling—noauto-linux-java-${i}.tsv exec:java
             done
         ;;
     esac

--- a/scripts/tiling.bat
+++ b/scripts/tiling.bat
@@ -24,9 +24,9 @@ for %%T in (neff-histopathology tubhiswt) do (
         REM )
 
         REM Run Java tiling performance tests - large image
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—large-win-java.tsv exec:java
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=15360 -Dtest.tileYStart=12928 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—large-win-java.tsv exec:java
         for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling-large-win-java-%%I.tsv exec:java
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=15360 -Dtest.tileYStart=12928 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling-large-win-java-%%I.tsv exec:java
         )
 
         REM Run Java tiling performance tests - medium image

--- a/scripts/tiling.bat
+++ b/scripts/tiling.bat
@@ -1,0 +1,53 @@
+@echo off
+REM Build with Jenkins CI.  This script is intended for use with the OME
+REM Jenkins CI infrastructure, though it may be useful as an example for
+REM how one might use various cmake options.
+
+REM So that statements like "set" work inside nested conditionals
+setlocal ENABLEDELAYEDEXPANSION
+setlocal ENABLEEXTENSIONS
+
+REM Run Java tiling performance tests
+for %%T in (neff-histopathology tubhiswt) do (
+    set test=%%T
+    set input=unknown
+
+    cd %WORKSPACE%\source
+
+    if [!test!] == [neff-histopathology] (
+        set input=%DATA_DIR%\ndpi\neff-histopathology\Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
+
+        REM Run Java tiling performance tests - very large image
+        REM call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        REM for /L %%I IN (1,1,!iterations!) do (
+            REM call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        REM )
+
+        REM Run Java tiling performance tests - large image
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+
+        REM Run Java tiling performance tests - medium image
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+    )
+    if [!test!] == [tubhiswt] (
+        set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
+
+        REM Run Java tiling performance tests - auto tiling
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+
+        REM Run Java tiling performance tests - manual tiling
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        for /L %%I IN (1,1,!iterations!) do (
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+        )
+    )
+)

--- a/scripts/tiling.bat
+++ b/scripts/tiling.bat
@@ -18,36 +18,36 @@ for %%T in (neff-histopathology tubhiswt) do (
         set input=%DATA_DIR%\ndpi\neff-histopathology\Bazla-14-100-brain - 2015-06-19 23.34.11.ndpi
 
         REM Run Java tiling performance tests - very large image
-        REM call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        REM call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling-win-java.tsv exec:java
         REM for /L %%I IN (1,1,!iterations!) do (
-            REM call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+            REM call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=122880 -Dtest.tileYStart=103424 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling-win-java-%%I.tsv exec:java
         REM )
 
         REM Run Java tiling performance tests - large image
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—large-win-java.tsv exec:java
         for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=30720 -Dtest.tileYStart=25856 -Dtest.series=1 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling-large-win-java-%%I.tsv exec:java
         )
 
         REM Run Java tiling performance tests - medium image
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.autoTile=false -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling-medium—win-java.tsv exec:java
         for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=7680 -Dtest.tileYStart=6464 -Dtest.autoTile=false -Dtest.tileOperator="-" -Dtest.tileIncrement=64 -Dtest.series=2 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—medium-win-java-%%I.tsv exec:java
         )
     )
     if [!test!] == [tubhiswt] (
         set input=%DATA_DIR%\tubhiswt-4D\tubhiswt_C0_TP0.ome.tif
 
         REM Run Java tiling performance tests - auto tiling
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—autotile-win-java.tsv exec:java
         for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—autotile-win-java-%%I.tsv exec:java
         )
 
         REM Run Java tiling performance tests - manual tiling
-        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java.tsv exec:java
+        call mvn -P tiling -Dtest.iterations=%iterations% -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—noauto-win-java.tsv exec:java
         for /L %%I IN (1,1,!iterations!) do (
-            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-metadata-win-java-%%I.tsv exec:java
+            call mvn -P tiling -Dtest.iterations=1 -Dtest.input=!input! -Dtest.tileXStart=512 -Dtest.tileYStart=512 -Dtest.autoTile=false -Dtest.output=%outdir%\!test!-java.ome.xml -Dtest.results=%resultsdir%\!test!-tiling—noauto-win-java-%%I.tsv exec:java
         )
     )
 )


### PR DESCRIPTION
This is another follow up PR to https://github.com/openmicroscopy/ome-files-performance/pull/44

The benchmarking scripts have been refactored to split the three benchmarking tests into their own individual scripts. The main run scripts will by default run all of the possible benchmarks but can be configured to run one or more individual tests by passing in the testname when running.

To test:
- Ensure the benchmarks build and run for both Windows and Linux
- Ensure that individual tests can be configured by selecting 'metadata', 'pixeldata' or 'tiling'