### PR TITLE
Consume latest OME Files C++ image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/ome-files-cpp-u1604:0.3.1
+FROM openmicroscopy/ome-files-cpp-u1604:latest
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # Install JDK7 and Maven


### PR DESCRIPTION
In preparation of the addition of the [tiling benchmarks in C++](https://trello.com/c/cBajJzL5/14-tiling-performance-c) matching https://github.com/openmicroscopy/ome-files-performance/pull/44, this PR bumps the version of the Docker image used for running the Linux benchmarks and for Travis to use the latest version (i.e. the development 0.4.0 version)

There should be nothing specific to be done here, just checking that Travis is green. For the final benchmark, this image will be bumped to a tagged version.
