### PR TITLE
pixels-performance: Add missing boost/filesystem.hpp include

### DIFF
--- a/src/main/cpp/pixels-performance.cpp
+++ b/src/main/cpp/pixels-performance.cpp
@@ -44,6 +44,8 @@
 #include <memory>
 #include <vector>
 
+#include <boost/filesystem.hpp>
+
 #include <ome/compat/array.h>
 #include <ome/common/log.h>
 


### PR DESCRIPTION
Needed to build with Boost 1.62 on Ubuntu 16.10.

The include is made explicit here; was previously implicit via some other header.]

Testing: Check builds remain green.