### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,10 @@ endif()
 list(APPEND CMAKE_MODULE_PATH
      "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-project(ome-files-performance
-        VERSION 0.2.1
+set(release-name "ome-files-performance")
+set(release-version "0.2.1") # unreleased
+project("${release-name}"
+        VERSION "${release-version}"
         LANGUAGES CXX)
 
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ list(APPEND CMAKE_MODULE_PATH
      "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 project(ome-files-performance
-        VERSION 0.0.1
+        VERSION 0.2.1
         LANGUAGES CXX)
 
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")


### PR DESCRIPTION
Following the release of [OME Files 0.5.0](http://www.openmicroscopy.org/2017/12/04/ome-files-0-5-0.html), this PR increments the patch number

See also https://github.com/openmicroscopy/ome-documentation/pull/1819