### PR TITLE
Variant and pyramid support

### DIFF
--- a/src/main/cpp/basic-tile-performance.cpp
+++ b/src/main/cpp/basic-tile-performance.cpp
@@ -8,6 +8,7 @@
  *   - University of Dundee
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
+ * Copyright © 2018 Quantitative Imaging Systems, LLC
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -72,7 +73,7 @@ using ome::xml::model::enums::PixelType;
 namespace
 {
 
-  struct RandomFillVisitor : public boost::static_visitor<>
+  struct RandomFillVisitor
   {
     RandomFillVisitor():
       rng(9343)
@@ -177,7 +178,7 @@ namespace
                                t.pixeltype);
         // Fill with random data, to avoid the filesystem not writing
         // (or compressing) empty data blocks as an optimisation.
-        boost::apply_visitor(random_fill, buf.vbuffer());
+        ome::compat::visit(random_fill, buf.vbuffer());
 
         boost::filesystem::remove(t.output_file);
         auto tiff = TIFF::open(t.output_file, "w8");

--- a/src/main/cpp/basic-tile-performance.cpp
+++ b/src/main/cpp/basic-tile-performance.cpp
@@ -174,7 +174,7 @@ namespace
 
         std::cout << "TEST: [" << t.iteration << "] " << t.description << std::endl;
 
-        VariantPixelBuffer buf(boost::extents[t.tilexsize][t.tileysize][1][1][1][1][1][1][1],
+        VariantPixelBuffer buf(boost::extents[t.tilexsize][t.tileysize][1][1],
                                t.pixeltype);
         // Fill with random data, to avoid the filesystem not writing
         // (or compressing) empty data blocks as an optimisation.

--- a/src/main/cpp/pixels-performance.cpp
+++ b/src/main/cpp/pixels-performance.cpp
@@ -8,6 +8,7 @@
  *   - University of Dundee
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
+ * Copyright © 2018 Quantitative Imaging Systems, LLC
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -118,7 +119,7 @@ int main(int argc, char *argv[])
                     reader.setPlane(plane);
                     std::unique_ptr<ome::files::VariantPixelBuffer>& buf = planes.at(plane);
                     buf = std::make_unique<ome::files::VariantPixelBuffer>
-                      (boost::extents[1][1][1][1][1][1][1][1][1],
+                      (boost::extents[1][1][1][1],
                        reader.getPixelType(),
                        ome::files::PixelBufferBase::make_storage_order(reader.getDimensionOrder(), reader.isInterleaved()));
                     reader.openBytes(plane, *buf);


### PR DESCRIPTION
This repo had been neglected for the mpark variant updated merged into all the other repositories.  It also needs the 4D pixelbuffer change as part of https://github.com/ome/ome-files-cpp/pull/100

Testing: Re-run the tests?

Future change: With the tile writing improvements in the pyramid PR, the C++ tests can now do tile writing via the FormatWriter interface to match Java where it would make sense to do so.